### PR TITLE
Freeze DatabaseManager storage topology

### DIFF
--- a/src/infra/persistence/database_manager.py
+++ b/src/infra/persistence/database_manager.py
@@ -142,13 +142,18 @@ class DatabaseManager:
                 db_name = DB_NAME
 
         # 2.1 Database Localization Enforcement
-        # Ensure the persistent file is strictly within the .serapeum isolation folder
+        # Ensure persistent DB files are canonicalized under the symbolic .serapeum root.
+        # Legal roots are <Application-root>\.serapeum or <Project-root>\.serapeum.
+        # Avoid fragile directory-listing checks and never let db_name escape the root.
         if db_name != ":memory:":
-            if not self.root_dir.endswith(".serapeum") and ".serapeum" not in os.listdir(self.root_dir or "."):
-                 self.root_dir = os.path.join(self.root_dir, ".serapeum")
-                 os.makedirs(self.root_dir, exist_ok=True)
-            self.db_path = os.path.join(self.root_dir, db_name)
+            input_root = os.path.abspath(root_dir)
+            if os.path.basename(os.path.normpath(input_root)).lower() != ".serapeum":
+                input_root = os.path.join(input_root, ".serapeum")
+            os.makedirs(input_root, exist_ok=True)
+            self.root_dir = input_root
+            self.db_path = os.path.join(self.root_dir, os.path.basename(str(db_name)))
         else:
+            self.root_dir = os.path.abspath(root_dir)
             self.db_path = ":memory:"
 
         # Thread-local storage for connections

--- a/src/tests/test_database_manager_storage_topology.py
+++ b/src/tests/test_database_manager_storage_topology.py
@@ -1,0 +1,78 @@
+﻿# -*- coding: utf-8 -*-
+"""
+test_database_manager_storage_topology.py
+
+Packet 1: Storage topology freeze.
+
+Proves DatabaseManager canonicalizes normal SQLite DBs under the approved
+symbolic .serapeum root without fragile directory-listing behavior.
+"""
+
+from pathlib import Path
+
+from src.infra.persistence.database_manager import DatabaseManager
+
+
+def _close(db: DatabaseManager) -> None:
+    try:
+        db.close_all_connections()
+    except Exception:
+        db.close_connection()
+
+
+def test_root_dir_is_canonicalized_under_serapeum(tmp_path):
+    project_root = tmp_path / "Project A"
+
+    db = DatabaseManager(root_dir=str(project_root), db_name="project.sqlite3")
+    try:
+        expected_root = project_root / ".serapeum"
+        assert Path(db.root_dir) == expected_root.resolve()
+        assert Path(db.db_path) == expected_root.resolve() / "project.sqlite3"
+        assert expected_root.exists()
+    finally:
+        _close(db)
+
+
+def test_existing_serapeum_root_is_not_nested(tmp_path):
+    serapeum_root = tmp_path / "Project A" / ".serapeum"
+
+    db = DatabaseManager(root_dir=str(serapeum_root), db_name="project.sqlite3")
+    try:
+        assert Path(db.root_dir) == serapeum_root.resolve()
+        assert Path(db.db_path) == serapeum_root.resolve() / "project.sqlite3"
+        assert ".serapeum/.serapeum" not in db.db_path.replace("\\", "/")
+    finally:
+        _close(db)
+
+
+def test_positional_project_db_file_is_localized_under_serapeum(tmp_path):
+    project_root = tmp_path / "Project A"
+    requested_db_path = project_root / "outside.sqlite3"
+
+    db = DatabaseManager(str(requested_db_path))
+    try:
+        expected_root = project_root / ".serapeum"
+        assert Path(db.root_dir) == expected_root.resolve()
+        assert Path(db.db_path) == expected_root.resolve() / "outside.sqlite3"
+    finally:
+        _close(db)
+
+
+def test_positional_serapeum_db_file_stays_under_serapeum(tmp_path):
+    serapeum_root = tmp_path / "Project A" / ".serapeum"
+    requested_db_path = serapeum_root / "inside.sqlite3"
+
+    db = DatabaseManager(str(requested_db_path))
+    try:
+        assert Path(db.root_dir) == serapeum_root.resolve()
+        assert Path(db.db_path) == serapeum_root.resolve() / "inside.sqlite3"
+    finally:
+        _close(db)
+
+
+def test_memory_database_preserves_memory_path(tmp_path):
+    db = DatabaseManager(root_dir=str(tmp_path), db_name=":memory:")
+    try:
+        assert db.db_path == ":memory:"
+    finally:
+        _close(db)


### PR DESCRIPTION
## Task class

Release task / source task

## Scope

Packet 1 — Storage topology freeze.

This PR makes `DatabaseManager` canonicalize persistent SQLite database files under the approved symbolic `.serapeum` root and removes the fragile `os.listdir(...)` localization condition.

## Changed files

- `src/infra/persistence/database_manager.py`
- `src/tests/test_database_manager_storage_topology.py`

## What changed

- Persistent DB roots now canonicalize deterministically to `<root>/.serapeum` unless the caller already passes a `.serapeum` root.
- `:memory:` DBs continue to preserve `db_path == ':memory:'`.
- Explicit DB filenames are sanitized with `os.path.basename(...)` so `db_name` cannot escape the canonical storage root.
- Added focused tests for:
  - project-root canonicalization,
  - existing `.serapeum` root preservation,
  - positional DB path localization,
  - no nested `.serapeum/.serapeum`,
  - memory DB preservation.

## Explicit non-scope

- No packaging changes.
- No dependency changes.
- No vector-store implementation changes in this packet.
- No runtime-advisor work.
- No branch deletion.

## Verification expected from local run

```powershell
py -m py_compile src/infra/persistence/database_manager.py src/tests/test_database_manager_storage_topology.py
py -m pytest -q src/tests/test_database_manager.py src/tests/test_database_manager_storage_topology.py src/tests/test_verify_doc_facts.py
```

## Risk frame

- Packaging risk: none.
- Windows risk: medium-low; path behavior intentionally Windows-safe.
- Rollback risk: low/medium; localized to DB path canonicalization.