### PR TITLE
Close mounted chat project isolation path

### DIFF
--- a/src/tests/test_chat_project_isolation.py
+++ b/src/tests/test_chat_project_isolation.py
@@ -1,0 +1,127 @@
+﻿# -*- coding: utf-8 -*-
+"""
+test_chat_project_isolation.py
+
+Packet 6: Project isolation / chat session residue closure.
+
+Locks release-critical chat behavior:
+
+- A response created for an old chat token must not be delivered after reset.
+- A response created for Project A must not be delivered after Project B becomes active.
+- Late worker errors must be dropped under the same token/project guard.
+- Mounted chat runtime always uses the active project and does not accept stale snapshot UI state.
+"""
+
+from types import SimpleNamespace
+
+from src.application.services.mounted_chat_runtime import run_mounted_chat_query
+from src.ui.pages.chat_page import ChatPage
+
+
+def _chat_shell(active_project_id="ProjectA", token=0):
+    chat = object.__new__(ChatPage)
+    chat._chat_session_token = token
+    chat.controller = SimpleNamespace(active_project_id=active_project_id)
+    chat.messages = []
+
+    def _capture(sender, text, **_kwargs):
+        chat.messages.append((sender, text))
+
+    chat.add_message = _capture
+    return chat
+
+
+def test_current_chat_request_accepts_matching_token_and_project():
+    chat = _chat_shell(active_project_id="ProjectA", token=7)
+
+    assert chat._is_current_chat_request(7, "ProjectA") is True
+
+
+def test_current_chat_request_rejects_old_session_token():
+    chat = _chat_shell(active_project_id="ProjectA", token=8)
+
+    assert chat._is_current_chat_request(7, "ProjectA") is False
+
+
+def test_current_chat_request_rejects_old_project_response_after_project_change():
+    chat = _chat_shell(active_project_id="ProjectB", token=7)
+
+    assert chat._is_current_chat_request(7, "ProjectA") is False
+
+
+def test_late_chat_worker_error_is_dropped_after_project_change():
+    chat = _chat_shell(active_project_id="ProjectB", token=3)
+
+    chat._deliver_chat_error(3, "ProjectA", RuntimeError("late old-project failure"))
+
+    assert chat.messages == []
+
+
+def test_late_chat_worker_error_is_dropped_after_session_reset():
+    chat = _chat_shell(active_project_id="ProjectA", token=4)
+
+    chat._deliver_chat_error(3, "ProjectA", RuntimeError("late old-token failure"))
+
+    assert chat.messages == []
+
+
+def test_current_chat_worker_error_is_delivered_for_current_project_and_token():
+    chat = _chat_shell(active_project_id="ProjectA", token=4)
+
+    chat._deliver_chat_error(4, "ProjectA", RuntimeError("current failure"))
+
+    assert chat.messages == [("System", "Error: current failure")]
+
+
+class _RecorderOrchestrator:
+    def __init__(self):
+        self.calls = []
+
+    def answer_question(self, *, query, project_id, snapshot_id=None):
+        self.calls.append(
+            {
+                "query": query,
+                "project_id": project_id,
+                "snapshot_id": snapshot_id,
+            }
+        )
+        return {
+            "answer": f"answer for {project_id}",
+            "mode": "answered",
+            "citations": [],
+            "support_facts": [],
+        }
+
+
+def test_mounted_chat_runtime_uses_active_project_and_no_snapshot_ui_state():
+    orchestrator = _RecorderOrchestrator()
+    controller = SimpleNamespace(
+        active_project_id="ProjectB",
+        orchestrator=orchestrator,
+        job_manager=None,
+    )
+
+    result = run_mounted_chat_query(controller, "what is this document?")
+
+    assert result["answer"] == "answer for ProjectB"
+    assert orchestrator.calls == [
+        {
+            "query": "what is this document?",
+            "project_id": "ProjectB",
+            "snapshot_id": None,
+        }
+    ]
+
+
+def test_mounted_chat_runtime_refuses_without_active_project():
+    controller = SimpleNamespace(
+        active_project_id=None,
+        orchestrator=_RecorderOrchestrator(),
+        job_manager=None,
+    )
+
+    result = run_mounted_chat_query(controller, "hello")
+
+    assert result["mode"] == "error"
+    assert result["compliance_status"] == "PROJECT_UNAVAILABLE"
+    assert "No active project" in result["answer"]

--- a/src/ui/pages/chat_page.py
+++ b/src/ui/pages/chat_page.py
@@ -131,6 +131,20 @@ class ChatPage(BasePage):
         self.attached_files = []
         self._refresh_attachment_label()
 
+    def _is_current_chat_request(self, request_token: int, request_project_id: Optional[str]) -> bool:
+        """Return True only for responses belonging to the current mounted chat session."""
+        if request_token != self._chat_session_token:
+            return False
+        if request_project_id != getattr(self.controller, "active_project_id", None):
+            return False
+        return True
+
+    def _deliver_chat_error(self, request_token: int, request_project_id: Optional[str], error: Exception) -> None:
+        """Drop late worker errors from a closed or changed project session."""
+        if not self._is_current_chat_request(request_token, request_project_id):
+            return
+        self.add_message("System", f"Error: {str(error)}")
+
     def send_message(self, event=None):
         msg = (self.entry_msg.get() or "").strip()
         if not msg and not self.attached_files:
@@ -156,9 +170,7 @@ class ChatPage(BasePage):
                     candidate_fact_suggestions = res.get("candidate_fact_suggestions", [])
                     source_lanes = res.get("source_lanes", {})
                     def _deliver():
-                        if request_token != self._chat_session_token:
-                            return
-                        if request_project_id != getattr(self.controller, "active_project_id", None):
+                        if not self._is_current_chat_request(request_token, request_project_id):
                             return
                         self.add_message(
                             "Serapeum",
@@ -170,7 +182,10 @@ class ChatPage(BasePage):
                         )
                     self.safe_ui_after(0, _deliver)
                 except Exception as e:
-                    self.safe_ui_after(0, lambda: self.add_message("System", f"Error: {str(e)}"))
+                    self.safe_ui_after(
+                        0,
+                        lambda err=e, token=request_token, project=request_project_id: self._deliver_chat_error(token, project, err),
+                    )
 
             threading.Thread(target=_ask, daemon=True).start()
         else:


### PR DESCRIPTION
## Task class

Source task / release-gate task

## Scope

Packet 6 — Project isolation / chat session residue closure.

This PR closes the remaining mounted chat isolation seam: late worker errors are now dropped using the same token/project guard already used for successful responses.

## Changed files

- `src/ui/pages/chat_page.py`
- `src/tests/test_chat_project_isolation.py`

## What changed

- Added `ChatPage._is_current_chat_request(...)` as the single token/project delivery guard.
- Added `ChatPage._deliver_chat_error(...)` so late worker exceptions are dropped after project close/change/session reset.
- Reused the same guard for successful response delivery.
- Added regression tests proving:
  - matching token/project is accepted,
  - old session tokens are rejected,
  - old-project responses are rejected after project change,
  - late worker errors are dropped after project change,
  - late worker errors are dropped after session reset,
  - current worker errors are still delivered,
  - mounted chat runtime uses active project only,
  - mounted chat runtime refuses when no project is active.

## Explicit non-scope

- No packaging changes.
- No dependency changes.
- No runtime-advisor work.
- No branch deletion.

## Local Windows verification supplied by owner/operator

```powershell
py -m py_compile src/ui/pages/chat_page.py src/application/services/mounted_chat_runtime.py src/tests/test_chat_project_isolation.py
py -m pytest -q src/tests/test_chat_project_isolation.py src/tests/test_file_inspector_evidence_lanes.py src/tests/test_dashboard_honesty_schema_resilience.py src/tests/test_fact_review_truth_state_closure.py src/tests/test_truth_path_inconsistency_closure.py src/tests/test_verify_doc_facts.py
```

Result:

```text
43 passed in 0.81s
```

## Risk frame

- Packaging risk: none.
- Windows risk: low; tests passed on Windows.
- Rollback risk: medium-low; source path changes chat delivery guard behavior.