### PR TITLE
Align docs with publish truth statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 SerapeumAI is a Windows-first, local-first AECO review workspace.
 
 It helps engineers and reviewers:
+
 - ingest project files into a project workspace
 - inspect deterministic extraction and AI analysis separately
 - review facts on the Facts page with lineage / evidence support
 - ask questions in Expert Chat and get a direct answer first, with optional evidence behind it
 
-SerapeumAI is **review assistance** with evidence and provenance. It is **not** a guaranteed-compliance or approval engine.
+SerapeumAI is **review assistance** with evidence and provenance. It is **not** a guaranteed-compliance, legal approval, or autonomous design-authoring engine.
 
 ## Run
 
@@ -21,9 +22,10 @@ python run.py
 ## Runtime contract
 
 - Windows is the baseline platform.
-- LM Studio must be installed and running locally.
+- LM Studio must be installed and running locally for the current mounted runtime path.
 - The publish generative runtime is the single model `qwen2.5-coder-7b-instruct`.
 - Embeddings remain separate from the generative model.
+- Calculations and deterministic checks must be performed by application code/tools, not by LLM arithmetic.
 
 ## Mounted workflow
 
@@ -39,43 +41,76 @@ python run.py
   - shows a direct answer first
   - can show a compact source-basis banner when helpful
   - keeps behind-the-scenes evidence behind an optional **Show Evidence** action
-  - resets visible chat history when the active project closes or changes
-
-Chat history should reset when the active project closes or changes.
   - exposes these evidence lanes only when expanded:
     - Trusted Facts
     - Extracted Evidence
     - Linked Support
     - AI-Generated Synthesis
+  - resets visible chat history when the active project closes or changes
+  - drops late responses/errors from old project sessions
 
 ## Trust and provenance
 
 - Trusted Facts remain the strongest source class.
+- `VALIDATED` and `HUMAN_CERTIFIED` facts are trusted answer sources.
+- `CANDIDATE` facts are visible for review but do not govern answers.
+- `REJECTED` facts are excluded from trusted answer paths.
 - AI-generated synthesis is clearly labeled non-governing.
-- Linked Support is clearly labeled non-trusted candidate support.
-- When trusted facts are incomplete, SerapeumAI may still answer from grounded extraction or linked support and will label that source class explicitly.
+- Linked Support is clearly labeled support, not certified truth.
+- When trusted facts are incomplete, SerapeumAI may answer from grounded extraction or linked support only when that source class is explicitly labeled.
 
+## Evidence and inspection
+
+- Deterministic extraction and parser/OCR output must remain separated from AI/VLM output.
+- File Inspector separates:
+  - consolidated review,
+  - full metadata,
+  - raw deterministic extraction,
+  - AI output only.
+- AI/VLM output does not become certified truth unless promoted through the review/certification workflow.
+- Deterministic extraction evidence can build trusted document facts through the build-facts path.
+
+## Storage and project isolation
+
+- Persistent project storage is localized under the project `.serapeum` root.
+- The normal SQLite database is the authority.
+- Vector/retrieval stores are derived support, not governing truth.
+- Project A must not answer from Project B.
+- Mounted chat requests are bound to the active project/session.
+
+## Dashboard honesty
+
+- Dashboard labels must not overclaim health or trust.
+- Qualified facts are counted separately from all built facts.
+- Missing optional extractor/runtime columns must degrade safely.
+- Schedule/P6 truth labels must not claim verified critical path unless deterministic float data supports it.
 
 ## Clean shutdown
+
 - Red-X close should internally close the project before destroying the app window.
 - Closing the main window should end the live session cleanly.
 - Background analysis should stop cleanly when the app is closed.
 - Reopening the app should not silently resume abandoned prior work without a new explicit user trigger.
 
-
 ## Schedule interaction
+
 - The Schedule page should allow clicking a schedule/Gantt activity without crashing.
 - If linked schedule facts are available, they should be shown.
 - If evidence is unavailable, the app should degrade gracefully and say so honestly.
 
-
 ## Interactive responsiveness
+
 - Interactive chat should stay responsive even when background ingest/extract work exists.
 - Background backlog should yield to active chat use in the mounted workflow.
 
-## Interactive priority over backlog
-- Interactive chat should stay responsive even when background ingest/extract work exists.
-- Background backlog should yield to active chat use in the mounted workflow.
+## Publish status
 
+The current repo has passed a sequence of source/test closure packets, but this README does **not** by itself declare a final publish pass.
 
-- Mounted chat history resets when the active project closes or changes.
+Before a publish pass, run the final local Windows release test and packaging proof.
+
+See:
+
+```text
+docs/internal/PUBLISH_TRUTH_STATEMENT.md
+```

--- a/docs/internal/PUBLISH_TRUTH_STATEMENT.md
+++ b/docs/internal/PUBLISH_TRUTH_STATEMENT.md
@@ -1,0 +1,159 @@
+# SerapeumAI Publish Truth Statement
+
+Task class: release task / documentation-control artifact  
+Status: publish-closure statement, not a final publish pass  
+Authority: current `main` after Packet 8 merge
+
+---
+
+## 1. Purpose
+
+This document states what the current repository has actually proven during the publish-closure rail.
+
+It is intentionally conservative. It does not claim final publish readiness until the final Windows release test and packaging proof are complete.
+
+---
+
+## 2. Product truth
+
+SerapeumAI is a Windows-first, local-first AECO review workspace.
+
+It provides evidence-backed review assistance through:
+
+- deterministic extraction,
+- fact building,
+- human review/certification,
+- lineage/provenance,
+- mounted File Inspector views,
+- mounted Facts page,
+- mounted Expert Chat.
+
+SerapeumAI is not:
+
+- a guaranteed-compliance engine,
+- a legal approval engine,
+- a cloud-required product,
+- a generic chatbot,
+- a design-authoring tool,
+- an autonomous agent that silently edits project files or models.
+
+---
+
+## 3. Proven closure packets
+
+### Packet 1 — Storage topology freeze
+
+Proven:
+
+- persistent project DB paths canonicalize under `.serapeum`,
+- `.serapeum/.serapeum` nesting is prevented,
+- memory DB behavior remains preserved.
+
+### Packet 2 — Truth-path inconsistency closure
+
+Proven:
+
+- mounted `VALIDATED` document facts are visible to the trusted fact query path,
+- chat does not falsely claim no certified/trusted facts when trusted document facts exist.
+
+### Packet 3 — Review actions truth-state closure
+
+Proven:
+
+- certify/reject actions route through the domain repository,
+- `HUMAN_CERTIFIED` facts enter trusted answer paths,
+- `REJECTED` facts are excluded from trusted answer paths.
+
+### Packet 4 — Dashboard honesty / schema resilience
+
+Proven:
+
+- missing optional extraction/runtime columns do not crash dashboard metrics,
+- dashboard fact counts separate built facts from qualified facts,
+- P6/critical-path status does not overclaim without deterministic support.
+
+### Packet 5 — File Inspector evidence-lane closure
+
+Proven:
+
+- File Inspector payload exposes four lanes:
+  1. Consolidated Review
+  2. Full Metadata
+  3. Raw Deterministic Extraction
+  4. AI Output Only
+- raw deterministic extraction excludes AI/VLM output,
+- AI/VLM output is clearly non-governing.
+
+### Packet 6 — Project isolation / chat residue closure
+
+Proven:
+
+- mounted chat response delivery is guarded by session token and active project,
+- late worker errors from old sessions/projects are dropped,
+- mounted chat runtime uses the active project only.
+
+### Packet 7 — Extractor proof / build-facts evidence closure
+
+Proven:
+
+- persisted deterministic extraction evidence can build `VALIDATED` document facts,
+- `BuildFactsJob` can persist document facts without chat/runtime/LLM,
+- `FactQueryAPI` can retrieve those trusted facts with lineage for the answer path.
+
+---
+
+## 4. What remains before final publish pass
+
+The repository is not final-publish passed until these are complete:
+
+1. Packet 8 docs alignment merged.
+2. Final local Windows source regression suite passes.
+3. Manual mounted workflow smoke test passes:
+   - open project,
+   - dashboard refresh,
+   - documents/file inspector,
+   - facts review actions,
+   - expert chat answer with evidence,
+   - close/change project,
+   - Red-X shutdown.
+4. Packaging proof passes last.
+5. Packaged app launches on Windows and repeats the critical smoke path.
+
+---
+
+## 5. Packaging boundary
+
+Packaging files remain sensitive and must not be edited unless explicitly approved:
+
+- `SerapeumAI_Portable.spec`
+- `build_portable.ps1`
+- `build_portable.bat`
+
+No dependency upgrades are approved by this statement.
+
+---
+
+## 6. Current publish truth
+
+Current state after Packets 1–7:
+
+```text
+Source/test closure rail: materially strengthened
+Docs alignment: in progress through Packet 8
+Final Windows release test: not yet complete
+Packaging proof: not yet complete
+Final publish verdict: NOT YET PASSED
+```
+
+---
+
+## 7. Next action
+
+After this document is merged:
+
+```text
+Run final Windows source regression suite
+→ run mounted workflow smoke test
+→ run packaging proof only after source/UI gates pass
+→ issue final PASS/FAIL publish verdict
+```


### PR DESCRIPTION
## Task class

Release task / documentation task

## Scope

Packet 8 — Documentation alignment / publish truth statement.

This PR aligns public/internal documentation with the actual source/test closure evidence from Packets 1–7 without claiming a final publish pass.

## Changed files

- `README.md`
- `docs/internal/PUBLISH_TRUTH_STATEMENT.md`

## What changed

- Cleaned duplicated README lines around chat reset and interactive responsiveness.
- Added explicit trust/provenance, evidence-lane, storage/isolation, dashboard honesty, and publish-status language.
- Added an internal publish truth statement listing proven Packets 1–7 and remaining gates before final publish pass.

## Explicit non-scope

- No `src/**` changes.
- No packaging changes.
- No dependency changes.
- No runtime-advisor work.
- No branch deletion.
- No final publish pass claim.

## Verification

GitHub compare shows docs-only changes:

- `README.md`
- `docs/internal/PUBLISH_TRUTH_STATEMENT.md`

Final Windows regression and packaging proof remain separate next gates.

## Risk frame

- Packaging risk: none.
- Windows risk: none.
- Rollback risk: low; docs-only packet.