### PR TITLE
Slim packaged test graph and quiet noisy startup logs

### DIFF
--- a/SerapeumAI_Portable.spec
+++ b/SerapeumAI_Portable.spec
@@ -80,7 +80,13 @@ for package_name in ("customtkinter",):
 
 hiddenimports = []
 try:
-    hiddenimports += collect_submodules("src")
+    # Keep broad app-module discovery for the current portable build, but never
+    # bundle test modules into the shipped application.
+    hiddenimports += [
+        name
+        for name in collect_submodules("src")
+        if not name.startswith("src.tests")
+    ]
 except Exception:
     pass
 
@@ -93,9 +99,13 @@ a = Analysis(
     hiddenimports=hiddenimports,
     hookspath=[],
     hooksconfig={},
-    runtime_hooks=[],
+    runtime_hooks=[
+        str(ROOT / "packaging" / "runtime_hooks" / "serapeum_runtime_log_hygiene.py"),
+    ],
     excludes=[
         "pytest",
+        "_pytest",
+        "src.tests",
         "setuptools.tests",
         "pip._vendor.pytest",
     ],

--- a/packaging/runtime_hooks/serapeum_runtime_log_hygiene.py
+++ b/packaging/runtime_hooks/serapeum_runtime_log_hygiene.py
@@ -1,0 +1,33 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime log hygiene for the packaged SerapeumAI app.
+
+This hook runs before run.py in the PyInstaller bundle. It keeps noisy optional
+library loggers from flooding the packaged app log during startup while leaving
+SerapeumAI's own loggers untouched.
+"""
+
+import logging
+import os
+
+
+# Keep matplotlib from emitting thousands of DEBUG font-discovery records into
+# the packaged app log when the application/root logger is in DEBUG mode.
+for logger_name in (
+    "matplotlib",
+    "matplotlib.font_manager",
+    "PIL",
+):
+    logging.getLogger(logger_name).setLevel(logging.WARNING)
+
+
+# Prefer a package-local matplotlib config/cache location so startup does not
+# repeatedly scan/rebuild more than necessary across packaged runs.
+try:
+    app_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    cache_root = os.path.join(app_root, ".serapeum", "cache", "matplotlib")
+    os.makedirs(cache_root, exist_ok=True)
+    os.environ.setdefault("MPLCONFIGDIR", cache_root)
+except Exception:
+    # Never block application startup from a log-hygiene hook.
+    pass


### PR DESCRIPTION
Wave 1A-2A packaging graph/log hygiene.

Changes:
- Excludes src.tests from PyInstaller hidden-import discovery.
- Adds explicit excludes for src.tests and _pytest.
- Adds a packaged runtime hook to quiet matplotlib/PIL startup log spam and use a package-local matplotlib cache.

Local Windows verification:
- spec syntax compiled
- runtime hook compiled
- focused regression passed: 31 passed, 1 warning in 3.15s
- clean PyInstaller build succeeded
- EXE produced: D:\SerapeumAI\dist\SerapeumAI_Portable\SerapeumAI.exe
- EXE size: 110,100,872 bytes
- xref check passed: src.tests not found in PyInstaller graph

No dependency upgrades, no runtime-advisor merge, no frozen artifact overwrite.