### PR TITLE
Add read-only runtime provider discovery

### DIFF
--- a/src/infra/services/runtime_provider_discovery.py
+++ b/src/infra/services/runtime_provider_discovery.py
@@ -1,0 +1,287 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Read-only runtime provider discovery for SerapeumAI.
+
+Wave 1B-1 rules:
+- no install
+- no start/stop
+- no model download
+- no model load/unload
+- no config mutation
+- no project data sent
+- local endpoint probes only
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Protocol
+from urllib import error, request
+from urllib.parse import urlparse
+
+
+STATUS_NOT_DETECTED = "not_detected"
+STATUS_DETECTED = "detected"
+STATUS_REACHABLE = "reachable"
+STATUS_DISABLED = "disabled"
+STATUS_UNREACHABLE = "unreachable"
+STATUS_UNSUPPORTED = "unsupported"
+
+
+def _no_side_effects() -> Dict[str, bool]:
+    return {
+        "internet_used": False,
+        "install_attempted": False,
+        "start_attempted": False,
+        "stop_attempted": False,
+        "download_attempted": False,
+        "model_load_attempted": False,
+        "model_unload_attempted": False,
+        "config_mutated": False,
+        "project_data_sent": False,
+    }
+
+
+def is_loopback_endpoint(endpoint: str) -> bool:
+    parsed = urlparse(str(endpoint or ""))
+    host = (parsed.hostname or "").strip().lower()
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+@dataclass(frozen=True)
+class ProviderDiscoveryResult:
+    provider_name: str
+    provider_type: str
+    endpoint: str
+    status: str
+    reason: str
+    capabilities: List[str] = field(default_factory=list)
+    side_effects: Dict[str, bool] = field(default_factory=_no_side_effects)
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def available(self) -> bool:
+        return self.status == STATUS_REACHABLE
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["available"] = self.available
+        data["capabilities"] = list(self.capabilities or [])
+        data["side_effects"] = dict(self.side_effects or {})
+        data["details"] = dict(self.details or {})
+        return data
+
+
+class ProviderDiscoveryAdapter(Protocol):
+    name: str
+
+    def discover(self) -> ProviderDiscoveryResult:
+        ...
+
+
+class HttpProviderDiscoveryAdapter:
+    def __init__(
+        self,
+        *,
+        name: str,
+        provider_type: str,
+        endpoint: str,
+        enabled: bool = True,
+        probe_path: str = "/v1/models",
+        capabilities: Optional[Iterable[str]] = None,
+        timeout_s: float = 1.5,
+        local_only: bool = True,
+    ) -> None:
+        self.name = str(name)
+        self.provider_type = str(provider_type)
+        self.endpoint = str(endpoint or "").rstrip("/")
+        self.enabled = bool(enabled)
+        self.probe_path = str(probe_path or "/").lstrip("/")
+        self.capabilities = list(capabilities or [])
+        self.timeout_s = float(timeout_s)
+        self.local_only = bool(local_only)
+
+    def _result(self, status: str, reason: str, *, details: Optional[Dict[str, Any]] = None) -> ProviderDiscoveryResult:
+        return ProviderDiscoveryResult(
+            provider_name=self.name,
+            provider_type=self.provider_type,
+            endpoint=self.endpoint,
+            status=status,
+            reason=reason,
+            capabilities=list(self.capabilities),
+            side_effects=_no_side_effects(),
+            details=dict(details or {}),
+        )
+
+    def _probe_url(self) -> str:
+        if not self.endpoint:
+            return ""
+        return f"{self.endpoint}/{self.probe_path}"
+
+    def discover(self) -> ProviderDiscoveryResult:
+        if not self.enabled:
+            return self._result(STATUS_DISABLED, "disabled_in_config")
+
+        if not self.endpoint:
+            return self._result(STATUS_NOT_DETECTED, "endpoint_not_configured")
+
+        if self.local_only and not is_loopback_endpoint(self.endpoint):
+            return self._result(
+                STATUS_UNSUPPORTED,
+                "non_local_endpoint_blocked",
+                details={"local_only": True},
+            )
+
+        probe_url = self._probe_url()
+        try:
+            req = request.Request(probe_url, method="GET")
+            with request.urlopen(req, timeout=self.timeout_s) as resp:
+                code = int(getattr(resp, "status", 200))
+            if 200 <= code < 300:
+                return self._result(
+                    STATUS_REACHABLE,
+                    "probe_ok",
+                    details={"http_status": code, "probe_method": "GET", "probe_path": f"/{self.probe_path}"},
+                )
+            return self._result(
+                STATUS_UNREACHABLE,
+                f"http_{code}",
+                details={"http_status": code, "probe_method": "GET", "probe_path": f"/{self.probe_path}"},
+            )
+        except error.HTTPError as exc:
+            code = getattr(exc, "code", "error")
+            return self._result(
+                STATUS_UNREACHABLE,
+                f"http_{code}",
+                details={"http_status": code, "probe_method": "GET", "probe_path": f"/{self.probe_path}"},
+            )
+        except Exception as exc:
+            return self._result(
+                STATUS_UNREACHABLE,
+                f"unreachable:{type(exc).__name__}",
+                details={"probe_method": "GET", "probe_path": f"/{self.probe_path}"},
+            )
+
+
+class LMStudioDiscoveryAdapter(HttpProviderDiscoveryAdapter):
+    def __init__(self, *, endpoint: str = "http://127.0.0.1:1234", enabled: bool = True, timeout_s: float = 1.5) -> None:
+        super().__init__(
+            name="lm_studio",
+            provider_type="lm_studio",
+            endpoint=endpoint,
+            enabled=enabled,
+            probe_path="/v1/models",
+            capabilities=["local_runtime", "openai_compatible", "model_listing", "chat_completions"],
+            timeout_s=timeout_s,
+            local_only=True,
+        )
+
+
+class OllamaDiscoveryAdapter(HttpProviderDiscoveryAdapter):
+    def __init__(self, *, endpoint: str = "http://127.0.0.1:11434", enabled: bool = True, timeout_s: float = 1.5) -> None:
+        super().__init__(
+            name="ollama",
+            provider_type="ollama",
+            endpoint=endpoint,
+            enabled=enabled,
+            probe_path="/api/tags",
+            capabilities=["local_runtime", "ollama", "model_listing"],
+            timeout_s=timeout_s,
+            local_only=True,
+        )
+
+
+class OpenAICompatibleLocalDiscoveryAdapter(HttpProviderDiscoveryAdapter):
+    def __init__(
+        self,
+        *,
+        name: str = "openai_compatible_local",
+        endpoint: str = "",
+        enabled: bool = False,
+        timeout_s: float = 1.5,
+    ) -> None:
+        super().__init__(
+            name=name,
+            provider_type="openai_compatible",
+            endpoint=endpoint,
+            enabled=enabled,
+            probe_path="/v1/models",
+            capabilities=["openai_compatible", "model_listing", "chat_completions"],
+            timeout_s=timeout_s,
+            local_only=True,
+        )
+
+
+class RuntimeProviderDiscoveryRegistry:
+    def __init__(self, adapters: Optional[Iterable[ProviderDiscoveryAdapter]] = None) -> None:
+        self.adapters = list(adapters or [])
+
+    @classmethod
+    def from_config(cls, config: Any) -> "RuntimeProviderDiscoveryRegistry":
+        providers: List[ProviderDiscoveryAdapter] = []
+
+        lm_cfg = config.get_section("lm_studio") if config else {}
+        providers.append(
+            LMStudioDiscoveryAdapter(
+                enabled=bool(lm_cfg.get("enabled", True)),
+                endpoint=str(lm_cfg.get("url", "http://127.0.0.1:1234")),
+            )
+        )
+
+        ollama_cfg = config.get_section("ollama") if config else {}
+        providers.append(
+            OllamaDiscoveryAdapter(
+                enabled=bool(ollama_cfg.get("enabled", True)),
+                endpoint=str(ollama_cfg.get("url", "http://127.0.0.1:11434")),
+            )
+        )
+
+        openai_cfg = config.get_section("openai_compatible") if config else {}
+        if not openai_cfg and config:
+            runtime_cfg = config.get_section("runtime_providers")
+            if isinstance(runtime_cfg.get("openai_compatible"), dict):
+                openai_cfg = runtime_cfg.get("openai_compatible", {})
+
+        openai_endpoint = str(openai_cfg.get("url") or openai_cfg.get("endpoint") or "")
+        openai_enabled = bool(openai_cfg.get("enabled", False))
+        if openai_endpoint or openai_enabled:
+            providers.append(
+                OpenAICompatibleLocalDiscoveryAdapter(
+                    name=str(openai_cfg.get("name", "openai_compatible_local")),
+                    endpoint=openai_endpoint,
+                    enabled=openai_enabled,
+                )
+            )
+
+        return cls(providers)
+
+    def discover(self) -> List[ProviderDiscoveryResult]:
+        results: List[ProviderDiscoveryResult] = []
+        for adapter in self.adapters:
+            try:
+                results.append(adapter.discover())
+            except Exception as exc:
+                results.append(
+                    ProviderDiscoveryResult(
+                        provider_name=getattr(adapter, "name", "unknown"),
+                        provider_type="unknown",
+                        endpoint="",
+                        status=STATUS_UNREACHABLE,
+                        reason=f"adapter_error:{type(exc).__name__}",
+                        capabilities=[],
+                        side_effects=_no_side_effects(),
+                    )
+                )
+        return sorted(results, key=lambda item: (item.provider_name, item.endpoint))
+
+    def discover_dicts(self) -> List[Dict[str, Any]]:
+        return [result.to_dict() for result in self.discover()]
+
+
+class RuntimeProviderDiscoveryService:
+    def __init__(self, config: Any = None, registry: Optional[RuntimeProviderDiscoveryRegistry] = None) -> None:
+        self.config = config
+        self.registry = registry or RuntimeProviderDiscoveryRegistry.from_config(config)
+
+    def discover_providers(self) -> List[Dict[str, Any]]:
+        return self.registry.discover_dicts()

--- a/src/tests/test_runtime_provider_discovery.py
+++ b/src/tests/test_runtime_provider_discovery.py
@@ -1,0 +1,218 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-1: read-only runtime provider discovery.
+
+These tests prove provider discovery is local/read-only and does not install,
+start, stop, download, load models, mutate config, or send project data.
+"""
+
+from urllib import error
+from unittest.mock import Mock, patch
+
+from src.infra.services.runtime_provider_discovery import (
+    LMStudioDiscoveryAdapter,
+    OllamaDiscoveryAdapter,
+    OpenAICompatibleLocalDiscoveryAdapter,
+    ProviderDiscoveryResult,
+    RuntimeProviderDiscoveryRegistry,
+    RuntimeProviderDiscoveryService,
+    STATUS_DISABLED,
+    STATUS_REACHABLE,
+    STATUS_UNREACHABLE,
+    STATUS_UNSUPPORTED,
+    is_loopback_endpoint,
+)
+
+
+class _Response:
+    def __init__(self, status=200):
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class _Config:
+    def __init__(self, sections):
+        self.sections = sections
+
+    def get_section(self, name):
+        return self.sections.get(name, {})
+
+
+def _assert_no_side_effects(result):
+    data = result.to_dict() if isinstance(result, ProviderDiscoveryResult) else result
+    assert data["side_effects"] == {
+        "internet_used": False,
+        "install_attempted": False,
+        "start_attempted": False,
+        "stop_attempted": False,
+        "download_attempted": False,
+        "model_load_attempted": False,
+        "model_unload_attempted": False,
+        "config_mutated": False,
+        "project_data_sent": False,
+    }
+
+
+def test_loopback_endpoint_detection_is_strict():
+    assert is_loopback_endpoint("http://127.0.0.1:1234")
+    assert is_loopback_endpoint("http://localhost:11434")
+    assert not is_loopback_endpoint("https://api.openai.com")
+    assert not is_loopback_endpoint("http://192.168.1.50:1234")
+
+
+def test_lm_studio_disabled_returns_disabled_without_http_probe():
+    urlopen = Mock()
+    adapter = LMStudioDiscoveryAdapter(enabled=False)
+
+    with patch("src.infra.services.runtime_provider_discovery.request.urlopen", urlopen):
+        result = adapter.discover()
+
+    assert result.status == STATUS_DISABLED
+    assert result.reason == "disabled_in_config"
+    assert urlopen.call_count == 0
+    _assert_no_side_effects(result)
+
+
+def test_lm_studio_reachable_uses_get_v1_models_only():
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["timeout"] = timeout
+        return _Response(200)
+
+    adapter = LMStudioDiscoveryAdapter(endpoint="http://127.0.0.1:1234", timeout_s=1.25)
+
+    with patch("src.infra.services.runtime_provider_discovery.request.urlopen", fake_urlopen):
+        result = adapter.discover()
+
+    assert result.status == STATUS_REACHABLE
+    assert result.reason == "probe_ok"
+    assert captured == {
+        "url": "http://127.0.0.1:1234/v1/models",
+        "method": "GET",
+        "timeout": 1.25,
+    }
+    assert "model_listing" in result.capabilities
+    _assert_no_side_effects(result)
+
+
+def test_lm_studio_unreachable_returns_structured_status():
+    adapter = LMStudioDiscoveryAdapter(endpoint="http://127.0.0.1:1234")
+
+    with patch(
+        "src.infra.services.runtime_provider_discovery.request.urlopen",
+        side_effect=error.URLError("offline"),
+    ):
+        result = adapter.discover()
+
+    assert result.status == STATUS_UNREACHABLE
+    assert result.reason.startswith("unreachable:")
+    _assert_no_side_effects(result)
+
+
+def test_ollama_reachable_uses_get_api_tags_only():
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["timeout"] = timeout
+        return _Response(200)
+
+    adapter = OllamaDiscoveryAdapter(endpoint="http://127.0.0.1:11434", timeout_s=1.0)
+
+    with patch("src.infra.services.runtime_provider_discovery.request.urlopen", fake_urlopen):
+        result = adapter.discover()
+
+    assert result.status == STATUS_REACHABLE
+    assert captured == {
+        "url": "http://127.0.0.1:11434/api/tags",
+        "method": "GET",
+        "timeout": 1.0,
+    }
+    assert "ollama" in result.capabilities
+    _assert_no_side_effects(result)
+
+
+def test_non_local_openai_compatible_endpoint_is_blocked_without_probe():
+    urlopen = Mock()
+    adapter = OpenAICompatibleLocalDiscoveryAdapter(
+        endpoint="https://api.openai.com",
+        enabled=True,
+    )
+
+    with patch("src.infra.services.runtime_provider_discovery.request.urlopen", urlopen):
+        result = adapter.discover()
+
+    assert result.status == STATUS_UNSUPPORTED
+    assert result.reason == "non_local_endpoint_blocked"
+    assert urlopen.call_count == 0
+    _assert_no_side_effects(result)
+
+
+def test_registry_discovers_in_deterministic_order():
+    registry = RuntimeProviderDiscoveryRegistry(
+        [
+            OllamaDiscoveryAdapter(enabled=False),
+            LMStudioDiscoveryAdapter(enabled=False),
+        ]
+    )
+
+    results = registry.discover()
+
+    assert [item.provider_name for item in results] == ["lm_studio", "ollama"]
+
+
+def test_from_config_includes_lm_studio_ollama_and_configured_openai_local():
+    config = _Config(
+        {
+            "lm_studio": {"enabled": False, "url": "http://127.0.0.1:1234"},
+            "ollama": {"enabled": False, "url": "http://127.0.0.1:11434"},
+            "openai_compatible": {
+                "enabled": True,
+                "url": "http://127.0.0.1:8000",
+                "name": "local_openai_server",
+            },
+        }
+    )
+
+    registry = RuntimeProviderDiscoveryRegistry.from_config(config)
+    names = [adapter.name for adapter in registry.adapters]
+
+    assert names == ["lm_studio", "ollama", "local_openai_server"]
+
+
+def test_service_returns_dicts_with_required_status_fields():
+    config = _Config(
+        {
+            "lm_studio": {"enabled": False, "url": "http://127.0.0.1:1234"},
+            "ollama": {"enabled": False, "url": "http://127.0.0.1:11434"},
+        }
+    )
+
+    service = RuntimeProviderDiscoveryService(config)
+    rows = service.discover_providers()
+
+    assert rows
+    for row in rows:
+        assert set(
+            [
+                "provider_name",
+                "provider_type",
+                "endpoint",
+                "status",
+                "reason",
+                "capabilities",
+                "side_effects",
+                "details",
+                "available",
+            ]
+        ).issubset(row.keys())
+        _assert_no_side_effects(row)


### PR DESCRIPTION
Wave 1B-1 runtime-platform source task.

Adds read-only provider discovery for:
- LM Studio via local GET /v1/models
- Ollama via local GET /api/tags
- configured local OpenAI-compatible endpoint via local GET /v1/models

Scope rules preserved:
- no install
- no start/stop
- no model download
- no model load/unload
- no config mutation
- no project data sent
- no UI changes
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 9 passed in 0.15s

Changed files:
- src/infra/services/runtime_provider_discovery.py
- src/tests/test_runtime_provider_discovery.py

Related: issue #25, master backlog #24.