### PR TITLE
Add runtime status presenter

### DIFF
--- a/src/infra/services/runtime_status_presenter.py
+++ b/src/infra/services/runtime_status_presenter.py
@@ -1,0 +1,160 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime status presenter.
+
+Converts read-only runtime provider discovery results into deterministic,
+honest status rows for future UI surfaces.
+
+This module is presentation-only:
+- no install
+- no start/stop
+- no download
+- no model load/unload
+- no config mutation
+- no provider probing
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+SUMMARY_NO_PROVIDER_REACHABLE = "no_provider_reachable"
+SUMMARY_PROVIDER_REACHABLE_MODEL_NOT_VERIFIED = "provider_reachable_model_not_verified"
+SUMMARY_PROVIDER_DISCOVERY_UNAVAILABLE = "provider_discovery_unavailable"
+
+
+_STATUS_DISPLAY = {
+    "disabled": "Disabled",
+    "not_detected": "Not detected",
+    "detected": "Detected",
+    "reachable": "Reachable",
+    "unreachable": "Unreachable",
+    "unsupported": "Unsupported",
+    "needs_consent": "Needs consent",
+}
+
+
+def _as_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _safe_side_effects(row: Dict[str, Any]) -> Dict[str, bool]:
+    value = row.get("side_effects")
+    if not isinstance(value, dict):
+        return {}
+
+    return {
+        "internet_used": bool(value.get("internet_used", False)),
+        "install_attempted": bool(value.get("install_attempted", False)),
+        "start_attempted": bool(value.get("start_attempted", False)),
+        "stop_attempted": bool(value.get("stop_attempted", False)),
+        "download_attempted": bool(value.get("download_attempted", False)),
+        "model_load_attempted": bool(value.get("model_load_attempted", False)),
+        "model_unload_attempted": bool(value.get("model_unload_attempted", False)),
+        "config_mutated": bool(value.get("config_mutated", False)),
+        "project_data_sent": bool(value.get("project_data_sent", False)),
+    }
+
+
+def _capability_summary(capabilities: Iterable[Any]) -> str:
+    caps = [str(item).replace("_", " ").strip() for item in _as_list(capabilities)]
+    caps = [item for item in caps if item]
+    return ", ".join(caps) if caps else "No capabilities reported"
+
+
+def _status_warning(status: str, reason: str) -> str:
+    status = str(status or "")
+    reason = str(reason or "")
+
+    if status == "reachable":
+        return "Provider endpoint is reachable. Model/task readiness is not yet verified."
+    if status == "disabled":
+        return "Provider is disabled by configuration. This is not an application failure."
+    if status == "unreachable":
+        return "Provider is configured but unreachable. AI features may remain unavailable until the provider is started by the user."
+    if status == "unsupported" and reason == "non_local_endpoint_blocked":
+        return "Endpoint is not local and is blocked by the local-first runtime policy."
+    if status == "not_detected":
+        return "Provider was not detected or no endpoint is configured."
+    if status == "needs_consent":
+        return "User consent is required before this action can proceed."
+    return ""
+
+
+def _action_hint(status: str, reason: str) -> str:
+    status = str(status or "")
+    reason = str(reason or "")
+
+    if status == "reachable":
+        return "Select or verify a model in a later model-readiness step."
+    if status == "disabled":
+        return "Enable this provider only if you want SerapeumAI to use it."
+    if status == "unreachable":
+        return "Open or configure the local provider outside SerapeumAI, then refresh status."
+    if status == "unsupported" and reason == "non_local_endpoint_blocked":
+        return "Use a localhost endpoint or explicitly configure a future non-local/cloud lane."
+    if status == "not_detected":
+        return "Install/configure this optional provider only if needed."
+    return "No action required."
+
+
+def present_runtime_provider_rows(discovery_rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+
+    for item in discovery_rows or []:
+        if not isinstance(item, dict):
+            continue
+
+        provider_name = str(item.get("provider_name") or "unknown")
+        endpoint = str(item.get("endpoint") or "")
+        status = str(item.get("status") or "unknown")
+        reason = str(item.get("reason") or "")
+        capabilities = _as_list(item.get("capabilities"))
+        side_effects = _safe_side_effects(item)
+
+        rows.append(
+            {
+                "provider_name": provider_name,
+                "provider_type": str(item.get("provider_type") or ""),
+                "endpoint": endpoint,
+                "status": status,
+                "display_status": _STATUS_DISPLAY.get(status, status.replace("_", " ").title() if status else "Unknown"),
+                "reason": reason,
+                "capability_summary": _capability_summary(capabilities),
+                "warning": _status_warning(status, reason),
+                "action_hint": _action_hint(status, reason),
+                "available": bool(item.get("available", status == "reachable")),
+                "model_readiness": "not_verified",
+                "side_effects": side_effects,
+                "side_effect_free": not any(side_effects.values()) if side_effects else False,
+            }
+        )
+
+    return sorted(rows, key=lambda row: (row["provider_name"], row["endpoint"]))
+
+
+def present_runtime_status(discovery_rows: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    provider_rows = present_runtime_provider_rows(discovery_rows)
+
+    if not provider_rows:
+        summary_status = SUMMARY_PROVIDER_DISCOVERY_UNAVAILABLE
+        summary_text = "Runtime provider discovery is unavailable."
+    elif any(row["available"] for row in provider_rows):
+        summary_status = SUMMARY_PROVIDER_REACHABLE_MODEL_NOT_VERIFIED
+        summary_text = "At least one local runtime provider is reachable. Model readiness is not yet verified."
+    else:
+        summary_status = SUMMARY_NO_PROVIDER_REACHABLE
+        summary_text = "No local runtime provider is currently reachable."
+
+    return {
+        "summary_status": summary_status,
+        "summary_text": summary_text,
+        "provider_count": len(provider_rows),
+        "reachable_provider_count": sum(1 for row in provider_rows if row["available"]),
+        "providers": provider_rows,
+    }

--- a/src/tests/test_runtime_status_presenter.py
+++ b/src/tests/test_runtime_status_presenter.py
@@ -1,0 +1,146 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-2: runtime status presenter tests.
+"""
+
+from src.infra.services.runtime_status_presenter import (
+    SUMMARY_NO_PROVIDER_REACHABLE,
+    SUMMARY_PROVIDER_DISCOVERY_UNAVAILABLE,
+    SUMMARY_PROVIDER_REACHABLE_MODEL_NOT_VERIFIED,
+    present_runtime_provider_rows,
+    present_runtime_status,
+)
+
+
+NO_SIDE_EFFECTS = {
+    "internet_used": False,
+    "install_attempted": False,
+    "start_attempted": False,
+    "stop_attempted": False,
+    "download_attempted": False,
+    "model_load_attempted": False,
+    "model_unload_attempted": False,
+    "config_mutated": False,
+    "project_data_sent": False,
+}
+
+
+def _row(name, status, *, endpoint="http://127.0.0.1:1234", reason="", available=None):
+    if available is None:
+        available = status == "reachable"
+    return {
+        "provider_name": name,
+        "provider_type": name,
+        "endpoint": endpoint,
+        "status": status,
+        "reason": reason,
+        "capabilities": ["local_runtime", "model_listing"],
+        "side_effects": dict(NO_SIDE_EFFECTS),
+        "available": available,
+        "details": {},
+    }
+
+
+def test_presenter_returns_discovery_unavailable_for_empty_input():
+    out = present_runtime_status([])
+
+    assert out["summary_status"] == SUMMARY_PROVIDER_DISCOVERY_UNAVAILABLE
+    assert out["provider_count"] == 0
+    assert out["reachable_provider_count"] == 0
+    assert out["providers"] == []
+
+
+def test_presenter_summarizes_no_reachable_provider_without_app_failure_language():
+    out = present_runtime_status(
+        [
+            _row("lm_studio", "disabled", reason="disabled_in_config"),
+            _row("ollama", "unreachable", endpoint="http://127.0.0.1:11434", reason="unreachable:URLError"),
+        ]
+    )
+
+    assert out["summary_status"] == SUMMARY_NO_PROVIDER_REACHABLE
+    assert out["reachable_provider_count"] == 0
+
+    rows = {row["provider_name"]: row for row in out["providers"]}
+    assert rows["lm_studio"]["display_status"] == "Disabled"
+    assert "not an application failure" in rows["lm_studio"]["warning"]
+    assert rows["ollama"]["display_status"] == "Unreachable"
+    assert "AI features may remain unavailable" in rows["ollama"]["warning"]
+
+
+def test_presenter_summarizes_reachable_provider_without_model_ready_overclaim():
+    out = present_runtime_status(
+        [
+            _row("lm_studio", "reachable", reason="probe_ok"),
+            _row("ollama", "disabled", endpoint="http://127.0.0.1:11434", reason="disabled_in_config"),
+        ]
+    )
+
+    assert out["summary_status"] == SUMMARY_PROVIDER_REACHABLE_MODEL_NOT_VERIFIED
+    assert out["reachable_provider_count"] == 1
+    assert "Model readiness is not yet verified" in out["summary_text"]
+
+    reachable = [row for row in out["providers"] if row["provider_name"] == "lm_studio"][0]
+    assert reachable["display_status"] == "Reachable"
+    assert reachable["model_readiness"] == "not_verified"
+    assert "Model/task readiness is not yet verified" in reachable["warning"]
+    assert "ready" not in reachable["display_status"].lower()
+
+
+def test_non_local_endpoint_is_presented_as_blocked_unsupported():
+    rows = present_runtime_provider_rows(
+        [
+            _row(
+                "openai_compatible_local",
+                "unsupported",
+                endpoint="https://api.openai.com",
+                reason="non_local_endpoint_blocked",
+                available=False,
+            )
+        ]
+    )
+
+    assert rows[0]["display_status"] == "Unsupported"
+    assert "not local" in rows[0]["warning"]
+    assert "localhost" in rows[0]["action_hint"]
+
+
+def test_rows_are_sorted_deterministically():
+    rows = present_runtime_provider_rows(
+        [
+            _row("ollama", "disabled", endpoint="http://127.0.0.1:11434"),
+            _row("lm_studio", "disabled", endpoint="http://127.0.0.1:1234"),
+        ]
+    )
+
+    assert [row["provider_name"] for row in rows] == ["lm_studio", "ollama"]
+
+
+def test_side_effect_flags_are_preserved_and_summarized():
+    dirty = _row("lm_studio", "reachable")
+    dirty["side_effects"]["download_attempted"] = True
+
+    rows = present_runtime_provider_rows([dirty])
+
+    assert rows[0]["side_effects"]["download_attempted"] is True
+    assert rows[0]["side_effect_free"] is False
+
+
+def test_side_effect_free_rows_report_true_when_all_flags_false():
+    rows = present_runtime_provider_rows([_row("lm_studio", "reachable")])
+
+    assert rows[0]["side_effect_free"] is True
+
+
+def test_provider_rows_never_claim_ready_in_wave_1b_2():
+    rows = present_runtime_provider_rows(
+        [
+            _row("lm_studio", "reachable"),
+            _row("ollama", "unreachable"),
+            _row("openai_compatible_local", "unsupported", endpoint="https://api.openai.com"),
+        ]
+    )
+
+    for row in rows:
+        assert row["model_readiness"] == "not_verified"
+        assert row["display_status"].lower() != "ready"


### PR DESCRIPTION
Wave 1B-2 runtime-platform source task.

Adds a presentation-only runtime status presenter for read-only provider discovery results.

Scope rules preserved:
- no provider probing in presenter
- no install
- no start/stop
- no model download
- no model load/unload
- no config mutation
- no project data sent
- no Settings UI changes
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 17 passed in 0.16s

Changed files:
- src/infra/services/runtime_status_presenter.py
- src/tests/test_runtime_status_presenter.py

Related: issue #27, master backlog #24.