### PR TITLE
Add runtime model catalog recommendation skeleton

### DIFF
--- a/src/infra/services/runtime_model_catalog.py
+++ b/src/infra/services/runtime_model_catalog.py
@@ -1,0 +1,244 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime model catalog and hardware recommendation skeleton.
+
+Wave 1B-4 rules:
+- recommendation only
+- no model download
+- no provider model load/unload
+- no runtime install
+- no internet use
+- no UI
+- no persistence
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Dict, Iterable, List, Optional
+
+from src.infra.services.runtime_consent import ConsentAction
+
+
+class ModelRole(str, Enum):
+    ROUTER = "router"
+    NARRATOR = "narrator"
+    STRUCTURED_JSON = "structured_json"
+    EVIDENCE_COMPRESSOR = "evidence_compressor"
+    VISION_HELPER = "vision_helper"
+    EMBEDDING = "embedding"
+    RERANKER = "reranker"
+
+
+class ModelProfileClass(str, Enum):
+    CONSERVATIVE = "conservative"
+    BALANCED = "balanced"
+    PERFORMANCE = "performance"
+
+
+class ModelFormat(str, Enum):
+    GGUF = "gguf"
+    ONNX = "onnx"
+    PROVIDER_MANAGED = "provider_managed"
+
+
+class ModelSizeClass(str, Enum):
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+
+
+@dataclass(frozen=True)
+class HardwareSnapshot:
+    gpu_available: bool
+    vram_total_mb: int
+    ram_total_mb: int
+    gpu_name: str = ""
+    os_name: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ModelCatalogEntry:
+    model_id: str
+    display_name: str
+    role: ModelRole
+    profile_class: ModelProfileClass
+    format: ModelFormat
+    quantization: str
+    estimated_size_class: ModelSizeClass
+    source_label: str
+    consent_actions_required: List[ConsentAction]
+    notes: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        data["role"] = self.role.value
+        data["profile_class"] = self.profile_class.value
+        data["format"] = self.format.value
+        data["estimated_size_class"] = self.estimated_size_class.value
+        data["consent_actions_required"] = [action.value for action in self.consent_actions_required]
+        return data
+
+
+@dataclass(frozen=True)
+class ModelRecommendation:
+    profile_class: ModelProfileClass
+    runtime_posture: str
+    model_posture: str
+    recommended_entries: List[ModelCatalogEntry]
+    warnings: List[str]
+    constraints: List[str]
+    side_effects: Dict[str, bool]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "profile_class": self.profile_class.value,
+            "runtime_posture": self.runtime_posture,
+            "model_posture": self.model_posture,
+            "recommended_entries": [entry.to_dict() for entry in self.recommended_entries],
+            "warnings": list(self.warnings),
+            "constraints": list(self.constraints),
+            "side_effects": dict(self.side_effects),
+        }
+
+
+def _no_side_effects() -> Dict[str, bool]:
+    return {
+        "internet_used": False,
+        "download_attempted": False,
+        "model_load_attempted": False,
+        "runtime_install_attempted": False,
+        "provider_mutated": False,
+        "project_data_sent": False,
+    }
+
+
+def classify_hardware(snapshot: HardwareSnapshot) -> ModelProfileClass:
+    if (not snapshot.gpu_available) or snapshot.vram_total_mb < 4096 or snapshot.ram_total_mb < 16000:
+        return ModelProfileClass.CONSERVATIVE
+    if snapshot.vram_total_mb >= 12288 and snapshot.ram_total_mb >= 32000:
+        return ModelProfileClass.PERFORMANCE
+    return ModelProfileClass.BALANCED
+
+
+def baseline_model_catalog() -> List[ModelCatalogEntry]:
+    consent_for_optional_model = [ConsentAction.INTERNET_USE, ConsentAction.MODEL_DOWNLOAD]
+
+    return [
+        ModelCatalogEntry(
+            model_id="safe-small-local-q4",
+            display_name="Safe Small Local Q4",
+            role=ModelRole.NARRATOR,
+            profile_class=ModelProfileClass.CONSERVATIVE,
+            format=ModelFormat.GGUF,
+            quantization="Q4_K_M",
+            estimated_size_class=ModelSizeClass.SMALL,
+            source_label="user-selected local model source",
+            consent_actions_required=consent_for_optional_model,
+            notes="Conservative low-resource text model posture.",
+        ),
+        ModelCatalogEntry(
+            model_id="balanced-7b-local-q4",
+            display_name="Balanced 7B Local Q4",
+            role=ModelRole.NARRATOR,
+            profile_class=ModelProfileClass.BALANCED,
+            format=ModelFormat.GGUF,
+            quantization="Q4_K_M",
+            estimated_size_class=ModelSizeClass.MEDIUM,
+            source_label="user-selected local model source",
+            consent_actions_required=consent_for_optional_model,
+            notes="Balanced 7B quantized text model posture for common 6-8 GB VRAM laptops.",
+        ),
+        ModelCatalogEntry(
+            model_id="balanced-structured-json-q5",
+            display_name="Balanced Structured JSON Q5",
+            role=ModelRole.STRUCTURED_JSON,
+            profile_class=ModelProfileClass.BALANCED,
+            format=ModelFormat.GGUF,
+            quantization="Q5_K_M",
+            estimated_size_class=ModelSizeClass.MEDIUM,
+            source_label="user-selected local model source",
+            consent_actions_required=consent_for_optional_model,
+            notes="Structured output helper posture for fact/tool JSON tasks.",
+        ),
+        ModelCatalogEntry(
+            model_id="performance-14b-local-q4",
+            display_name="Performance 14B Local Q4",
+            role=ModelRole.NARRATOR,
+            profile_class=ModelProfileClass.PERFORMANCE,
+            format=ModelFormat.GGUF,
+            quantization="Q4_K_M",
+            estimated_size_class=ModelSizeClass.LARGE,
+            source_label="user-selected local model source",
+            consent_actions_required=consent_for_optional_model,
+            notes="Higher-quality local model posture for high VRAM/RAM machines.",
+        ),
+        ModelCatalogEntry(
+            model_id="local-embedding-small",
+            display_name="Small Local Embedding Model",
+            role=ModelRole.EMBEDDING,
+            profile_class=ModelProfileClass.CONSERVATIVE,
+            format=ModelFormat.ONNX,
+            quantization="INT8-or-small-fp",
+            estimated_size_class=ModelSizeClass.SMALL,
+            source_label="bundled-or-user-selected local embedding source",
+            consent_actions_required=[],
+            notes="Embedding posture remains derived retrieval support only.",
+        ),
+    ]
+
+
+def catalog_for_profile(profile_class: ModelProfileClass, catalog: Optional[Iterable[ModelCatalogEntry]] = None) -> List[ModelCatalogEntry]:
+    rows = list(catalog or baseline_model_catalog())
+    allowed_profiles = {ModelProfileClass.CONSERVATIVE}
+
+    if profile_class == ModelProfileClass.BALANCED:
+        allowed_profiles.add(ModelProfileClass.BALANCED)
+    elif profile_class == ModelProfileClass.PERFORMANCE:
+        allowed_profiles.update({ModelProfileClass.BALANCED, ModelProfileClass.PERFORMANCE})
+
+    return [entry for entry in rows if entry.profile_class in allowed_profiles]
+
+
+def recommend_models_for_hardware(
+    snapshot: HardwareSnapshot,
+    *,
+    provider_reachable: bool = False,
+    catalog: Optional[Iterable[ModelCatalogEntry]] = None,
+) -> ModelRecommendation:
+    profile = classify_hardware(snapshot)
+    entries = catalog_for_profile(profile, catalog)
+
+    warnings: List[str] = []
+    constraints: List[str] = []
+
+    if not provider_reachable:
+        warnings.append("No reachable local runtime provider detected; recommendations are advisory only.")
+        constraints.append("A provider must be configured/reachable before model use.")
+
+    if profile == ModelProfileClass.CONSERVATIVE:
+        runtime_posture = "local_conservative"
+        model_posture = "small_low_vram_models"
+        warnings.append("Conservative profile selected; avoid vision-heavy or large-context models.")
+    elif profile == ModelProfileClass.BALANCED:
+        runtime_posture = "local_balanced"
+        model_posture = "balanced_7b_quantized"
+    else:
+        runtime_posture = "local_high_throughput"
+        model_posture = "high_quality_7b_to_14b_quantized"
+
+    constraints.append("Recommendations never download, install, or load models automatically.")
+
+    return ModelRecommendation(
+        profile_class=profile,
+        runtime_posture=runtime_posture,
+        model_posture=model_posture,
+        recommended_entries=entries,
+        warnings=warnings,
+        constraints=constraints,
+        side_effects=_no_side_effects(),
+    )

--- a/src/tests/test_runtime_model_catalog.py
+++ b/src/tests/test_runtime_model_catalog.py
@@ -1,0 +1,166 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-4: model catalog and hardware recommendation skeleton tests.
+"""
+
+from src.infra.services.runtime_consent import ConsentAction
+from src.infra.services.runtime_model_catalog import (
+    HardwareSnapshot,
+    ModelFormat,
+    ModelProfileClass,
+    ModelRole,
+    classify_hardware,
+    baseline_model_catalog,
+    catalog_for_profile,
+    recommend_models_for_hardware,
+)
+
+
+def test_8gb_vram_16gb_ram_maps_to_balanced_profile():
+    snapshot = HardwareSnapshot(
+        gpu_available=True,
+        gpu_name="NVIDIA RTX 4060 Laptop GPU",
+        vram_total_mb=8192,
+        ram_total_mb=16384,
+        os_name="nt",
+    )
+
+    assert classify_hardware(snapshot) == ModelProfileClass.BALANCED
+
+
+def test_no_gpu_maps_to_conservative_profile():
+    snapshot = HardwareSnapshot(
+        gpu_available=False,
+        vram_total_mb=0,
+        ram_total_mb=32768,
+    )
+
+    assert classify_hardware(snapshot) == ModelProfileClass.CONSERVATIVE
+
+
+def test_high_vram_high_ram_maps_to_performance_profile():
+    snapshot = HardwareSnapshot(
+        gpu_available=True,
+        vram_total_mb=16384,
+        ram_total_mb=65536,
+    )
+
+    assert classify_hardware(snapshot) == ModelProfileClass.PERFORMANCE
+
+
+def test_every_catalog_entry_has_required_metadata_and_consent_shape():
+    for entry in baseline_model_catalog():
+        row = entry.to_dict()
+
+        assert row["model_id"]
+        assert row["display_name"]
+        assert row["role"] in {role.value for role in ModelRole}
+        assert row["profile_class"] in {profile.value for profile in ModelProfileClass}
+        assert row["format"] in {fmt.value for fmt in ModelFormat}
+        assert row["quantization"]
+        assert row["estimated_size_class"]
+        assert "source_label" in row
+        assert "consent_actions_required" in row
+
+
+def test_optional_downloadable_models_require_internet_and_model_download_consent():
+    downloadable = [
+        entry
+        for entry in baseline_model_catalog()
+        if ConsentAction.MODEL_DOWNLOAD in entry.consent_actions_required
+    ]
+
+    assert downloadable
+    for entry in downloadable:
+        assert ConsentAction.INTERNET_USE in entry.consent_actions_required
+        assert ConsentAction.MODEL_DOWNLOAD in entry.consent_actions_required
+
+
+def test_embedding_entry_has_no_download_consent_requirement_in_skeleton():
+    embeddings = [entry for entry in baseline_model_catalog() if entry.role == ModelRole.EMBEDDING]
+
+    assert embeddings
+    for entry in embeddings:
+        assert ConsentAction.MODEL_DOWNLOAD not in entry.consent_actions_required
+
+
+def test_balanced_catalog_includes_balanced_7b_quantized_guidance():
+    entries = catalog_for_profile(ModelProfileClass.BALANCED)
+    ids = {entry.model_id for entry in entries}
+
+    assert "balanced-7b-local-q4" in ids
+    assert "balanced-structured-json-q5" in ids
+    assert "performance-14b-local-q4" not in ids
+
+
+def test_recommendation_for_8gb_vram_16gb_ram_is_balanced_7b_posture():
+    rec = recommend_models_for_hardware(
+        HardwareSnapshot(
+            gpu_available=True,
+            gpu_name="NVIDIA RTX 4060 Laptop GPU",
+            vram_total_mb=8192,
+            ram_total_mb=16384,
+            os_name="nt",
+        ),
+        provider_reachable=True,
+    )
+
+    row = rec.to_dict()
+
+    assert row["profile_class"] == ModelProfileClass.BALANCED.value
+    assert row["runtime_posture"] == "local_balanced"
+    assert row["model_posture"] == "balanced_7b_quantized"
+    assert any(entry["model_id"] == "balanced-7b-local-q4" for entry in row["recommended_entries"])
+
+
+def test_conservative_recommendation_warns_against_heavy_models():
+    rec = recommend_models_for_hardware(
+        HardwareSnapshot(gpu_available=False, vram_total_mb=0, ram_total_mb=8192),
+        provider_reachable=False,
+    )
+
+    row = rec.to_dict()
+
+    assert row["profile_class"] == ModelProfileClass.CONSERVATIVE.value
+    assert row["runtime_posture"] == "local_conservative"
+    assert row["model_posture"] == "small_low_vram_models"
+    assert any("avoid vision-heavy" in warning for warning in row["warnings"])
+
+
+def test_performance_recommendation_includes_performance_entry():
+    rec = recommend_models_for_hardware(
+        HardwareSnapshot(gpu_available=True, vram_total_mb=24576, ram_total_mb=65536),
+        provider_reachable=True,
+    )
+
+    ids = {entry["model_id"] for entry in rec.to_dict()["recommended_entries"]}
+
+    assert "performance-14b-local-q4" in ids
+
+
+def test_recommendation_has_no_runtime_side_effects():
+    rec = recommend_models_for_hardware(
+        HardwareSnapshot(gpu_available=True, vram_total_mb=8192, ram_total_mb=16384),
+        provider_reachable=False,
+    )
+
+    assert rec.to_dict()["side_effects"] == {
+        "internet_used": False,
+        "download_attempted": False,
+        "model_load_attempted": False,
+        "runtime_install_attempted": False,
+        "provider_mutated": False,
+        "project_data_sent": False,
+    }
+
+
+def test_recommendation_discloses_provider_missing_constraint():
+    rec = recommend_models_for_hardware(
+        HardwareSnapshot(gpu_available=True, vram_total_mb=8192, ram_total_mb=16384),
+        provider_reachable=False,
+    )
+
+    row = rec.to_dict()
+
+    assert any("No reachable local runtime provider" in warning for warning in row["warnings"])
+    assert any("provider must be configured" in constraint.lower() for constraint in row["constraints"])


### PR DESCRIPTION
Wave 1B-4 runtime-platform source task.

Adds a source-only model catalog and hardware recommendation skeleton.

Includes:
- model role definitions
- hardware profile classes
- static baseline model catalog entries
- recommendation decision logic
- consent-action requirements in catalog entries

Scope rules preserved:
- no model download
- no provider model load/unload
- no runtime install
- no internet use
- no UI
- no persistence
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 42 passed in 0.24s

Changed files:
- src/infra/services/runtime_model_catalog.py
- src/tests/test_runtime_model_catalog.py

Related: issue #31, master backlog #24.