### PR TITLE
Connect model recommendations to hardware seam

### DIFF
--- a/src/infra/services/runtime_model_catalog.py
+++ b/src/infra/services/runtime_model_catalog.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from src.infra.services.runtime_consent import ConsentAction
 
@@ -242,3 +242,80 @@ def recommend_models_for_hardware(
         constraints=constraints,
         side_effects=_no_side_effects(),
     )
+
+def hardware_snapshot_from_mapping(data: Dict[str, Any], *, ram_total_mb: int = 0) -> HardwareSnapshot:
+    """
+    Convert existing hardware utility output into the model-catalog HardwareSnapshot.
+
+    Expected GPU keys are compatible with src.utils.hardware_utils.get_gpu_info():
+    - available
+    - vram_total_mb
+    - gpu_name
+
+    RAM is supplied separately so tests and future platform-specific collectors can
+    inject it without depending on host hardware.
+    """
+    data = data or {}
+    return HardwareSnapshot(
+        gpu_available=bool(data.get("available", data.get("gpu_available", False))),
+        vram_total_mb=int(data.get("vram_total_mb", 0) or 0),
+        ram_total_mb=int(ram_total_mb or data.get("ram_total_mb", 0) or 0),
+        gpu_name=str(data.get("gpu_name", "") or ""),
+        os_name=str(data.get("os_name", "") or ""),
+    )
+
+
+def detect_hardware_snapshot(
+    *,
+    gpu_info_provider: Optional[Callable[[], Dict[str, Any]]] = None,
+    ram_total_mb_provider: Optional[Callable[[], int]] = None,
+) -> HardwareSnapshot:
+    """
+    Read-only hardware snapshot adapter.
+
+    This function does not benchmark, load models, start providers, download, or
+    mutate config. It only adapts the existing hardware detection seam into the
+    recommendation skeleton's HardwareSnapshot shape.
+    """
+    try:
+        if gpu_info_provider is None:
+            from src.utils.hardware_utils import get_gpu_info
+            gpu_info_provider = get_gpu_info
+
+        gpu_info = gpu_info_provider() or {}
+    except Exception:
+        gpu_info = {}
+
+    try:
+        ram_total_mb = int(ram_total_mb_provider() if ram_total_mb_provider else 0)
+    except Exception:
+        ram_total_mb = 0
+
+    return hardware_snapshot_from_mapping(gpu_info, ram_total_mb=ram_total_mb)
+
+
+def recommend_models_from_detected_hardware(
+    *,
+    provider_reachable: bool = False,
+    gpu_info_provider: Optional[Callable[[], Dict[str, Any]]] = None,
+    ram_total_mb_provider: Optional[Callable[[], int]] = None,
+    catalog: Optional[Iterable[ModelCatalogEntry]] = None,
+) -> ModelRecommendation:
+    """
+    Convenience wrapper for model recommendation using the read-only hardware seam.
+
+    Side-effect rule:
+    - detects hardware only,
+    - returns advisory recommendations,
+    - does not download/install/load/start anything.
+    """
+    snapshot = detect_hardware_snapshot(
+        gpu_info_provider=gpu_info_provider,
+        ram_total_mb_provider=ram_total_mb_provider,
+    )
+    return recommend_models_for_hardware(
+        snapshot,
+        provider_reachable=provider_reachable,
+        catalog=catalog,
+    )
+

--- a/src/tests/test_runtime_model_catalog_hardware_seam.py
+++ b/src/tests/test_runtime_model_catalog_hardware_seam.py
@@ -1,0 +1,133 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-4B: hardware seam integration tests.
+"""
+
+from src.infra.services.runtime_model_catalog import (
+    HardwareSnapshot,
+    ModelProfileClass,
+    detect_hardware_snapshot,
+    hardware_snapshot_from_mapping,
+    recommend_models_from_detected_hardware,
+)
+
+
+def test_hardware_snapshot_from_existing_gpu_info_mapping():
+    snapshot = hardware_snapshot_from_mapping(
+        {
+            "available": True,
+            "vram_total_mb": 8192,
+            "gpu_name": "NVIDIA RTX 4060 Laptop GPU",
+            "method": "pynvml",
+        },
+        ram_total_mb=16384,
+    )
+
+    assert snapshot == HardwareSnapshot(
+        gpu_available=True,
+        vram_total_mb=8192,
+        ram_total_mb=16384,
+        gpu_name="NVIDIA RTX 4060 Laptop GPU",
+        os_name="",
+    )
+
+
+def test_detect_hardware_snapshot_uses_injected_read_only_providers():
+    calls = {"gpu": 0, "ram": 0}
+
+    def fake_gpu_info():
+        calls["gpu"] += 1
+        return {
+            "available": True,
+            "vram_total_mb": 8192,
+            "gpu_name": "NVIDIA RTX 4060 Laptop GPU",
+        }
+
+    def fake_ram_total_mb():
+        calls["ram"] += 1
+        return 16384
+
+    snapshot = detect_hardware_snapshot(
+        gpu_info_provider=fake_gpu_info,
+        ram_total_mb_provider=fake_ram_total_mb,
+    )
+
+    assert calls == {"gpu": 1, "ram": 1}
+    assert snapshot.gpu_available is True
+    assert snapshot.vram_total_mb == 8192
+    assert snapshot.ram_total_mb == 16384
+
+
+def test_detect_hardware_snapshot_degrades_safely_when_detection_fails():
+    def broken_gpu_info():
+        raise RuntimeError("hardware detection failed")
+
+    def broken_ram_total_mb():
+        raise RuntimeError("ram detection failed")
+
+    snapshot = detect_hardware_snapshot(
+        gpu_info_provider=broken_gpu_info,
+        ram_total_mb_provider=broken_ram_total_mb,
+    )
+
+    assert snapshot.gpu_available is False
+    assert snapshot.vram_total_mb == 0
+    assert snapshot.ram_total_mb == 0
+
+
+def test_recommend_models_from_detected_hardware_maps_4060_laptop_to_balanced():
+    recommendation = recommend_models_from_detected_hardware(
+        provider_reachable=True,
+        gpu_info_provider=lambda: {
+            "available": True,
+            "vram_total_mb": 8192,
+            "gpu_name": "NVIDIA RTX 4060 Laptop GPU",
+        },
+        ram_total_mb_provider=lambda: 16384,
+    )
+
+    row = recommendation.to_dict()
+
+    assert row["profile_class"] == ModelProfileClass.BALANCED.value
+    assert row["runtime_posture"] == "local_balanced"
+    assert row["model_posture"] == "balanced_7b_quantized"
+    assert any(entry["model_id"] == "balanced-7b-local-q4" for entry in row["recommended_entries"])
+
+
+def test_recommend_models_from_detected_hardware_no_gpu_is_conservative():
+    recommendation = recommend_models_from_detected_hardware(
+        provider_reachable=False,
+        gpu_info_provider=lambda: {
+            "available": False,
+            "vram_total_mb": 0,
+            "gpu_name": "No GPU",
+        },
+        ram_total_mb_provider=lambda: 32768,
+    )
+
+    row = recommendation.to_dict()
+
+    assert row["profile_class"] == ModelProfileClass.CONSERVATIVE.value
+    assert row["runtime_posture"] == "local_conservative"
+    assert any("No reachable local runtime provider" in warning for warning in row["warnings"])
+
+
+def test_hardware_seam_recommendation_has_no_runtime_side_effects():
+    recommendation = recommend_models_from_detected_hardware(
+        provider_reachable=False,
+        gpu_info_provider=lambda: {
+            "available": True,
+            "vram_total_mb": 8192,
+            "gpu_name": "NVIDIA RTX 4060 Laptop GPU",
+        },
+        ram_total_mb_provider=lambda: 16384,
+    )
+
+    assert recommendation.to_dict()["side_effects"] == {
+        "internet_used": False,
+        "download_attempted": False,
+        "model_load_attempted": False,
+        "runtime_install_attempted": False,
+        "provider_mutated": False,
+        "project_data_sent": False,
+    }


### PR DESCRIPTION
Wave 1B-4B runtime-platform source task.

Connects the model recommendation skeleton to the existing read-only hardware detection seam without changing runtime/provider behavior.

Changes:
- adds hardware_snapshot_from_mapping
- adds detect_hardware_snapshot
- adds recommend_models_from_detected_hardware
- adds focused tests using injected hardware providers

Scope rules preserved:
- no model download
- no provider model load/unload
- no runtime install
- no internet use
- no UI
- no persistence
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 48 passed in 0.15s

Changed files:
- src/infra/services/runtime_model_catalog.py
- src/tests/test_runtime_model_catalog_hardware_seam.py

Related: issue #33, master backlog #24.