### PR TITLE
Add runtime provisioning design contract

### DIFF
--- a/src/infra/services/runtime_provisioning_contract.py
+++ b/src/infra/services/runtime_provisioning_contract.py
@@ -1,0 +1,259 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime provisioning design contract.
+
+This module defines future provisioning plans without executing them.
+
+Wave 1B-7 rules:
+- no operational provisioning
+- no provider start/stop
+- no model download
+- no model load/unload
+- no runtime install
+- no internet use
+- no config mutation
+- no persistence
+- no UI action behavior
+
+It is a design/source contract only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Dict, Iterable, List, Optional
+
+from src.infra.services.runtime_consent import (
+    ConsentAction,
+    ConsentRisk,
+    RuntimeConsentPolicy,
+    RuntimeConsentState,
+)
+
+
+class ProvisioningActionType(str, Enum):
+    INTERNET_CHECK = "internet_check"
+    MODEL_DOWNLOAD = "model_download"
+    RUNTIME_INSTALL = "runtime_install"
+    PROVIDER_START = "provider_start"
+    PROVIDER_STOP = "provider_stop"
+    MODEL_LOAD = "model_load"
+    MODEL_UNLOAD = "model_unload"
+    NON_LOCAL_ENDPOINT_ENABLE = "non_local_endpoint_enable"
+
+
+class ProvisioningPlanStatus(str, Enum):
+    BLOCKED = "blocked"
+    ELIGIBLE = "eligible"
+
+
+@dataclass(frozen=True)
+class ProvisioningSideEffects:
+    internet_used: bool = False
+    provider_mutated: bool = False
+    model_download_attempted: bool = False
+    model_load_attempted: bool = False
+    model_unload_attempted: bool = False
+    runtime_install_attempted: bool = False
+    config_mutated: bool = False
+    persistence_written: bool = False
+    project_data_may_leave_machine: bool = False
+
+    def to_dict(self) -> Dict[str, bool]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ProvisioningStep:
+    action_type: ProvisioningActionType
+    title: str
+    description: str
+    consent_actions_required: List[ConsentAction]
+    side_effects_declared: ProvisioningSideEffects
+    target: str = ""
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        data["action_type"] = self.action_type.value
+        data["consent_actions_required"] = [action.value for action in self.consent_actions_required]
+        data["side_effects_declared"] = self.side_effects_declared.to_dict()
+        return data
+
+
+@dataclass(frozen=True)
+class ProvisioningPlanValidation:
+    status: ProvisioningPlanStatus
+    missing_consent_actions: List[ConsentAction]
+    highest_risk: ConsentRisk
+    can_execute: bool
+    reasons: List[str]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "status": self.status.value,
+            "missing_consent_actions": [action.value for action in self.missing_consent_actions],
+            "highest_risk": self.highest_risk.value,
+            "can_execute": self.can_execute,
+            "reasons": list(self.reasons),
+        }
+
+
+_RISK_ORDER = {
+    ConsentRisk.LOW: 1,
+    ConsentRisk.MEDIUM: 2,
+    ConsentRisk.HIGH: 3,
+}
+
+
+_ACTION_CONSENT_MAP = {
+    ProvisioningActionType.INTERNET_CHECK: [ConsentAction.INTERNET_USE],
+    ProvisioningActionType.MODEL_DOWNLOAD: [ConsentAction.INTERNET_USE, ConsentAction.MODEL_DOWNLOAD],
+    ProvisioningActionType.RUNTIME_INSTALL: [ConsentAction.INTERNET_USE, ConsentAction.RUNTIME_INSTALL],
+    ProvisioningActionType.PROVIDER_START: [ConsentAction.PROVIDER_START],
+    ProvisioningActionType.PROVIDER_STOP: [ConsentAction.PROVIDER_STOP],
+    ProvisioningActionType.MODEL_LOAD: [ConsentAction.MODEL_LOAD],
+    ProvisioningActionType.MODEL_UNLOAD: [ConsentAction.MODEL_UNLOAD],
+    ProvisioningActionType.NON_LOCAL_ENDPOINT_ENABLE: [
+        ConsentAction.INTERNET_USE,
+        ConsentAction.NON_LOCAL_ENDPOINT_USE,
+    ],
+}
+
+
+def consent_actions_for_provisioning(action_type: ProvisioningActionType | str) -> List[ConsentAction]:
+    normalized = ProvisioningActionType(action_type)
+    return list(_ACTION_CONSENT_MAP[normalized])
+
+
+def declared_side_effects_for(action_type: ProvisioningActionType | str) -> ProvisioningSideEffects:
+    normalized = ProvisioningActionType(action_type)
+
+    if normalized == ProvisioningActionType.INTERNET_CHECK:
+        return ProvisioningSideEffects(internet_used=True)
+
+    if normalized == ProvisioningActionType.MODEL_DOWNLOAD:
+        return ProvisioningSideEffects(
+            internet_used=True,
+            model_download_attempted=True,
+            persistence_written=True,
+        )
+
+    if normalized == ProvisioningActionType.RUNTIME_INSTALL:
+        return ProvisioningSideEffects(
+            internet_used=True,
+            runtime_install_attempted=True,
+            config_mutated=True,
+            persistence_written=True,
+        )
+
+    if normalized in {ProvisioningActionType.PROVIDER_START, ProvisioningActionType.PROVIDER_STOP}:
+        return ProvisioningSideEffects(provider_mutated=True)
+
+    if normalized == ProvisioningActionType.MODEL_LOAD:
+        return ProvisioningSideEffects(model_load_attempted=True, provider_mutated=True)
+
+    if normalized == ProvisioningActionType.MODEL_UNLOAD:
+        return ProvisioningSideEffects(model_unload_attempted=True, provider_mutated=True)
+
+    if normalized == ProvisioningActionType.NON_LOCAL_ENDPOINT_ENABLE:
+        return ProvisioningSideEffects(
+            internet_used=True,
+            config_mutated=True,
+            persistence_written=True,
+            project_data_may_leave_machine=True,
+        )
+
+    return ProvisioningSideEffects()
+
+
+def build_provisioning_step(
+    action_type: ProvisioningActionType | str,
+    *,
+    title: str,
+    description: str,
+    target: str = "",
+    metadata: Optional[Dict[str, str]] = None,
+) -> ProvisioningStep:
+    normalized = ProvisioningActionType(action_type)
+    return ProvisioningStep(
+        action_type=normalized,
+        title=str(title or normalized.value),
+        description=str(description or ""),
+        consent_actions_required=consent_actions_for_provisioning(normalized),
+        side_effects_declared=declared_side_effects_for(normalized),
+        target=str(target or ""),
+        metadata=dict(metadata or {}),
+    )
+
+
+def _highest_risk_for(consent_actions: Iterable[ConsentAction]) -> ConsentRisk:
+    highest = ConsentRisk.LOW
+    for action in consent_actions:
+        requirement = RuntimeConsentPolicy.requirement_for(action)
+        if _RISK_ORDER[requirement.risk] > _RISK_ORDER[highest]:
+            highest = requirement.risk
+    return highest
+
+
+def validate_provisioning_plan(
+    steps: Iterable[ProvisioningStep],
+    consent_state: RuntimeConsentState,
+) -> ProvisioningPlanValidation:
+    rows = list(steps or [])
+    required_actions: List[ConsentAction] = []
+    reasons: List[str] = []
+
+    for step in rows:
+        for action in step.consent_actions_required:
+            if action not in required_actions:
+                required_actions.append(action)
+
+    missing = [action for action in required_actions if not consent_state.is_granted(action)]
+
+    if not rows:
+        reasons.append("No provisioning steps were supplied.")
+    for action in missing:
+        reasons.append(f"Missing consent: {action.value}")
+
+    highest = _highest_risk_for(required_actions) if required_actions else ConsentRisk.LOW
+    can_execute = bool(rows) and not missing
+
+    return ProvisioningPlanValidation(
+        status=ProvisioningPlanStatus.ELIGIBLE if can_execute else ProvisioningPlanStatus.BLOCKED,
+        missing_consent_actions=missing,
+        highest_risk=highest,
+        can_execute=can_execute,
+        reasons=reasons,
+    )
+
+
+def build_design_only_plan_summary(steps: Iterable[ProvisioningStep]) -> Dict[str, object]:
+    """
+    Return a serializable provisioning plan summary.
+
+    This function never executes the plan.
+    """
+    rows = list(steps or [])
+    all_actions: List[ConsentAction] = []
+    for step in rows:
+        for action in step.consent_actions_required:
+            if action not in all_actions:
+                all_actions.append(action)
+
+    side_effects = ProvisioningSideEffects()
+    merged = side_effects.to_dict()
+    for step in rows:
+        declared = step.side_effects_declared.to_dict()
+        for key, value in declared.items():
+            merged[key] = bool(merged.get(key, False) or value)
+
+    return {
+        "schema_version": 1,
+        "step_count": len(rows),
+        "steps": [step.to_dict() for step in rows],
+        "consent_actions_required": [action.value for action in all_actions],
+        "declared_side_effects": merged,
+        "executes": False,
+    }

--- a/src/tests/test_runtime_provisioning_contract.py
+++ b/src/tests/test_runtime_provisioning_contract.py
@@ -1,0 +1,165 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-7: runtime provisioning design contract tests.
+"""
+
+from src.infra.services.runtime_consent import (
+    ConsentAction,
+    ConsentDecision,
+    ConsentRisk,
+    ConsentScope,
+    RuntimeConsentState,
+)
+from src.infra.services.runtime_provisioning_contract import (
+    ProvisioningActionType,
+    ProvisioningPlanStatus,
+    build_design_only_plan_summary,
+    build_provisioning_step,
+    consent_actions_for_provisioning,
+    declared_side_effects_for,
+    validate_provisioning_plan,
+)
+
+
+def test_every_provisioning_action_maps_to_explicit_consent():
+    for action_type in ProvisioningActionType:
+        actions = consent_actions_for_provisioning(action_type)
+        assert actions
+        assert all(isinstance(action, ConsentAction) for action in actions)
+
+
+def test_model_download_requires_internet_and_model_download_consent():
+    actions = consent_actions_for_provisioning(ProvisioningActionType.MODEL_DOWNLOAD)
+
+    assert actions == [ConsentAction.INTERNET_USE, ConsentAction.MODEL_DOWNLOAD]
+
+
+def test_runtime_install_requires_internet_and_runtime_install_consent():
+    actions = consent_actions_for_provisioning(ProvisioningActionType.RUNTIME_INSTALL)
+
+    assert actions == [ConsentAction.INTERNET_USE, ConsentAction.RUNTIME_INSTALL]
+
+
+def test_non_local_endpoint_requires_high_risk_boundary_consent():
+    actions = consent_actions_for_provisioning(ProvisioningActionType.NON_LOCAL_ENDPOINT_ENABLE)
+    effects = declared_side_effects_for(ProvisioningActionType.NON_LOCAL_ENDPOINT_ENABLE)
+
+    assert actions == [ConsentAction.INTERNET_USE, ConsentAction.NON_LOCAL_ENDPOINT_USE]
+    assert effects.internet_used is True
+    assert effects.project_data_may_leave_machine is True
+    assert effects.config_mutated is True
+
+
+def test_action_side_effects_are_distinguishable():
+    assert declared_side_effects_for(ProvisioningActionType.PROVIDER_START).provider_mutated is True
+    assert declared_side_effects_for(ProvisioningActionType.MODEL_LOAD).model_load_attempted is True
+    assert declared_side_effects_for(ProvisioningActionType.MODEL_UNLOAD).model_unload_attempted is True
+    assert declared_side_effects_for(ProvisioningActionType.RUNTIME_INSTALL).runtime_install_attempted is True
+    assert declared_side_effects_for(ProvisioningActionType.MODEL_DOWNLOAD).model_download_attempted is True
+
+
+def test_plan_validation_is_deny_by_default_without_consent():
+    state = RuntimeConsentState()
+    step = build_provisioning_step(
+        ProvisioningActionType.MODEL_DOWNLOAD,
+        title="Download model",
+        description="Future model download plan.",
+        target="balanced-7b-local-q4",
+    )
+
+    validation = validate_provisioning_plan([step], state)
+
+    assert validation.status == ProvisioningPlanStatus.BLOCKED
+    assert validation.can_execute is False
+    assert validation.missing_consent_actions == [ConsentAction.INTERNET_USE, ConsentAction.MODEL_DOWNLOAD]
+    assert validation.highest_risk == ConsentRisk.MEDIUM
+
+
+def test_plan_becomes_eligible_only_after_all_required_consents_are_granted():
+    state = RuntimeConsentState()
+    step = build_provisioning_step(
+        ProvisioningActionType.PROVIDER_START,
+        title="Start provider",
+        description="Future provider start plan.",
+        target="lm_studio",
+    )
+
+    blocked = validate_provisioning_plan([step], state)
+    assert blocked.can_execute is False
+
+    state.record_decision(ConsentAction.PROVIDER_START, ConsentDecision.APPROVED, scope=ConsentScope.SESSION)
+
+    allowed = validate_provisioning_plan([step], state)
+    assert allowed.status == ProvisioningPlanStatus.ELIGIBLE
+    assert allowed.can_execute is True
+    assert allowed.missing_consent_actions == []
+
+
+def test_rejected_consent_keeps_plan_blocked():
+    state = RuntimeConsentState()
+    state.record_decision(ConsentAction.RUNTIME_INSTALL, ConsentDecision.REJECTED, scope=ConsentScope.SESSION)
+
+    step = build_provisioning_step(
+        ProvisioningActionType.RUNTIME_INSTALL,
+        title="Install runtime",
+        description="Future runtime install plan.",
+        target="ollama",
+    )
+
+    validation = validate_provisioning_plan([step], state)
+
+    assert validation.status == ProvisioningPlanStatus.BLOCKED
+    assert validation.can_execute is False
+    assert ConsentAction.RUNTIME_INSTALL in validation.missing_consent_actions
+
+
+def test_empty_plan_is_blocked_and_non_executing():
+    validation = validate_provisioning_plan([], RuntimeConsentState())
+
+    assert validation.status == ProvisioningPlanStatus.BLOCKED
+    assert validation.can_execute is False
+    assert "No provisioning steps were supplied." in validation.reasons
+
+
+def test_design_only_summary_never_executes():
+    step = build_provisioning_step(
+        ProvisioningActionType.MODEL_LOAD,
+        title="Load model",
+        description="Future model load plan.",
+        target="chat",
+    )
+
+    summary = build_design_only_plan_summary([step])
+
+    assert summary["schema_version"] == 1
+    assert summary["step_count"] == 1
+    assert summary["executes"] is False
+    assert summary["declared_side_effects"]["model_load_attempted"] is True
+    assert summary["declared_side_effects"]["provider_mutated"] is True
+
+
+def test_multi_step_summary_merges_consent_and_side_effects():
+    steps = [
+        build_provisioning_step(
+            ProvisioningActionType.MODEL_DOWNLOAD,
+            title="Download model",
+            description="Future model download.",
+        ),
+        build_provisioning_step(
+            ProvisioningActionType.MODEL_LOAD,
+            title="Load model",
+            description="Future model load.",
+        ),
+    ]
+
+    summary = build_design_only_plan_summary(steps)
+
+    assert summary["consent_actions_required"] == [
+        ConsentAction.INTERNET_USE.value,
+        ConsentAction.MODEL_DOWNLOAD.value,
+        ConsentAction.MODEL_LOAD.value,
+    ]
+    assert summary["declared_side_effects"]["internet_used"] is True
+    assert summary["declared_side_effects"]["model_download_attempted"] is True
+    assert summary["declared_side_effects"]["model_load_attempted"] is True
+    assert summary["executes"] is False


### PR DESCRIPTION
Wave 1B-7 runtime-platform source/design task.

Adds a design-only provisioning contract before any operational provisioning is implemented.

Changes:
- provisioning action vocabulary
- consent-action mapping
- side-effect declaration contract
- provisioning step/plan validation data models
- design-only plan summary
- tests proving deny-by-default and non-executing behavior

Scope rules preserved:
- no operational provisioning
- no UI action buttons
- no persistence
- no provider mutation
- no model download/load/unload
- no runtime install
- no internet use
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 71 passed in 1.23s

Changed files:
- src/infra/services/runtime_provisioning_contract.py
- src/tests/test_runtime_provisioning_contract.py

Related: issue #39, master backlog #24.