### PR TITLE
Add runtime consent UX copy contract

### DIFF
--- a/src/infra/services/runtime_consent_copy.py
+++ b/src/infra/services/runtime_consent_copy.py
@@ -1,0 +1,164 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime consent UX copy contract.
+
+This module freezes user-facing consent language before future runtime
+provisioning actions are wired.
+
+It is copy/contract only:
+- no operational provisioning
+- no UI action buttons
+- no provider mutation
+- no model download/load/unload
+- no runtime install
+- no internet use
+- no persistence
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Dict, Iterable, List
+
+from src.infra.services.runtime_consent import ConsentAction, RuntimeConsentPolicy
+from src.infra.services.runtime_provisioning_contract import ProvisioningStep
+
+
+@dataclass(frozen=True)
+class ConsentCopy:
+    action: ConsentAction
+    title: str
+    body: str
+    confirm_label: str
+    cancel_label: str
+    warning: str
+
+    def to_dict(self) -> Dict[str, str]:
+        data = asdict(self)
+        data["action"] = self.action.value
+        return data
+
+
+_COPY: Dict[ConsentAction, ConsentCopy] = {
+    ConsentAction.INTERNET_USE: ConsentCopy(
+        action=ConsentAction.INTERNET_USE,
+        title="Allow internet access?",
+        body=(
+            "SerapeumAI can use the internet for this requested runtime action. "
+            "Project documents will not be uploaded by this permission alone."
+        ),
+        confirm_label="Allow internet for this action",
+        cancel_label="Cancel",
+        warning="Do not continue if this project must remain fully offline.",
+    ),
+    ConsentAction.MODEL_DOWNLOAD: ConsentCopy(
+        action=ConsentAction.MODEL_DOWNLOAD,
+        title="Download a local AI model?",
+        body=(
+            "SerapeumAI can download the selected model file and store it on this computer. "
+            "This uses the internet and changes local disk state."
+        ),
+        confirm_label="Download model",
+        cancel_label="Cancel",
+        warning="Model files may be large. Confirm the source, size, and license before continuing.",
+    ),
+    ConsentAction.PROVIDER_START: ConsentCopy(
+        action=ConsentAction.PROVIDER_START,
+        title="Start local runtime provider?",
+        body=(
+            "SerapeumAI can start the selected local runtime provider on this computer. "
+            "This changes local machine runtime state but does not upload project data by itself."
+        ),
+        confirm_label="Start local provider",
+        cancel_label="Cancel",
+        warning="Starting a provider may consume CPU, RAM, or GPU resources.",
+    ),
+    ConsentAction.PROVIDER_STOP: ConsentCopy(
+        action=ConsentAction.PROVIDER_STOP,
+        title="Stop local runtime provider?",
+        body=(
+            "SerapeumAI can stop the selected local runtime provider on this computer. "
+            "This changes local machine runtime state."
+        ),
+        confirm_label="Stop local provider",
+        cancel_label="Cancel",
+        warning="Stopping a provider may interrupt running local AI tasks.",
+    ),
+    ConsentAction.MODEL_LOAD: ConsentCopy(
+        action=ConsentAction.MODEL_LOAD,
+        title="Load model into local runtime?",
+        body=(
+            "SerapeumAI can ask the local runtime to load the selected model. "
+            "This changes local runtime state and may consume CPU, RAM, or GPU resources."
+        ),
+        confirm_label="Load model",
+        cancel_label="Cancel",
+        warning="Large models may make the computer slower while loaded.",
+    ),
+    ConsentAction.MODEL_UNLOAD: ConsentCopy(
+        action=ConsentAction.MODEL_UNLOAD,
+        title="Unload model from local runtime?",
+        body=(
+            "SerapeumAI can ask the local runtime to unload the selected model. "
+            "This changes local runtime state."
+        ),
+        confirm_label="Unload model",
+        cancel_label="Cancel",
+        warning="Unloading a model may stop active local AI tasks that depend on it.",
+    ),
+    ConsentAction.NON_LOCAL_ENDPOINT_USE: ConsentCopy(
+        action=ConsentAction.NON_LOCAL_ENDPOINT_USE,
+        title="Use a non-local AI endpoint?",
+        body=(
+            "This endpoint is not local to this computer. Project text, prompts, metadata, "
+            "or extracted content may leave the machine if this endpoint is used."
+        ),
+        confirm_label="Use non-local endpoint",
+        cancel_label="Cancel",
+        warning="Use only if your project rules allow external or cloud processing.",
+    ),
+    ConsentAction.RUNTIME_INSTALL: ConsentCopy(
+        action=ConsentAction.RUNTIME_INSTALL,
+        title="Install runtime component?",
+        body=(
+            "SerapeumAI can install the selected runtime component on this computer. "
+            "This uses the internet and changes local machine state."
+        ),
+        confirm_label="Install runtime component",
+        cancel_label="Cancel",
+        warning="Only install components from trusted sources and with permission for this workstation.",
+    ),
+}
+
+
+def consent_copy_for(action: ConsentAction | str) -> ConsentCopy:
+    normalized = ConsentAction(action)
+    return _COPY[normalized]
+
+
+def all_consent_copy() -> Dict[str, Dict[str, str]]:
+    return {action.value: _COPY[action].to_dict() for action in sorted(_COPY, key=lambda item: item.value)}
+
+
+def provisioning_plan_copy_summary(steps: Iterable[ProvisioningStep]) -> Dict[str, object]:
+    rows = list(steps or [])
+    consent_actions: List[ConsentAction] = []
+
+    for step in rows:
+        for action in step.consent_actions_required:
+            if action not in consent_actions:
+                consent_actions.append(action)
+
+    warnings = [consent_copy_for(action).warning for action in consent_actions]
+    requirements = [RuntimeConsentPolicy.requirement_for(action).to_dict() for action in consent_actions]
+
+    return {
+        "schema_version": 1,
+        "step_count": len(rows),
+        "requires_user_approval": bool(consent_actions),
+        "executes": False,
+        "consent_actions": [action.value for action in consent_actions],
+        "titles": [consent_copy_for(action).title for action in consent_actions],
+        "warnings": warnings,
+        "requirements": requirements,
+    }

--- a/src/tests/test_runtime_consent_copy.py
+++ b/src/tests/test_runtime_consent_copy.py
@@ -1,0 +1,144 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-8: runtime consent UX copy contract tests.
+"""
+
+from src.infra.services.runtime_consent import ConsentAction
+from src.infra.services.runtime_consent_copy import (
+    all_consent_copy,
+    consent_copy_for,
+    provisioning_plan_copy_summary,
+)
+from src.infra.services.runtime_provisioning_contract import (
+    ProvisioningActionType,
+    build_provisioning_step,
+)
+
+
+def test_every_consent_action_has_copy():
+    copy = all_consent_copy()
+
+    assert set(copy.keys()) == {action.value for action in ConsentAction}
+    for action, row in copy.items():
+        assert row["action"] == action
+        assert row["title"]
+        assert row["body"]
+        assert row["confirm_label"]
+        assert row["cancel_label"] == "Cancel"
+        assert row["warning"]
+
+
+def test_internet_copy_does_not_claim_project_upload():
+    copy = consent_copy_for(ConsentAction.INTERNET_USE)
+
+    assert "internet" in copy.body.lower()
+    assert "project documents will not be uploaded by this permission alone" in copy.body.lower()
+    assert "fully offline" in copy.warning.lower()
+
+
+def test_model_download_copy_mentions_internet_and_local_disk_change():
+    copy = consent_copy_for(ConsentAction.MODEL_DOWNLOAD)
+
+    body = copy.body.lower()
+    assert "download" in body
+    assert "internet" in body
+    assert "local disk" in body
+    assert "license" in copy.warning.lower()
+
+
+def test_runtime_install_copy_mentions_internet_and_machine_state_change():
+    copy = consent_copy_for(ConsentAction.RUNTIME_INSTALL)
+
+    body = copy.body.lower()
+    assert "install" in body
+    assert "internet" in body
+    assert "local machine state" in body
+
+
+def test_provider_start_copy_mentions_local_machine_resources_not_upload():
+    copy = consent_copy_for(ConsentAction.PROVIDER_START)
+
+    assert "local runtime provider" in copy.body.lower()
+    assert "does not upload project data by itself" in copy.body.lower()
+    assert "gpu" in copy.warning.lower()
+
+
+def test_model_load_copy_mentions_local_runtime_resources():
+    copy = consent_copy_for(ConsentAction.MODEL_LOAD)
+
+    body = copy.body.lower()
+    assert "local runtime" in body
+    assert "cpu" in body
+    assert "gpu" in body
+
+
+def test_non_local_endpoint_copy_explicitly_warns_project_data_may_leave_machine():
+    copy = consent_copy_for(ConsentAction.NON_LOCAL_ENDPOINT_USE)
+
+    body = copy.body.lower()
+    warning = copy.warning.lower()
+    assert "not local" in body
+    assert "project text" in body
+    assert "may leave the machine" in body
+    assert "cloud" in warning or "external" in warning
+
+
+def test_copy_never_implies_automatic_approval_or_hidden_execution():
+    forbidden = [
+        "automatically approved",
+        "without asking",
+        "silently",
+        "background download",
+        "will proceed",
+    ]
+
+    for row in all_consent_copy().values():
+        text = " ".join(
+            [
+                row["title"],
+                row["body"],
+                row["confirm_label"],
+                row["cancel_label"],
+                row["warning"],
+            ]
+        ).lower()
+        for phrase in forbidden:
+            assert phrase not in text
+
+
+def test_plan_copy_summary_is_non_executing_and_collects_copy():
+    steps = [
+        build_provisioning_step(
+            ProvisioningActionType.MODEL_DOWNLOAD,
+            title="Download model",
+            description="Future model download.",
+        ),
+        build_provisioning_step(
+            ProvisioningActionType.MODEL_LOAD,
+            title="Load model",
+            description="Future model load.",
+        ),
+    ]
+
+    summary = provisioning_plan_copy_summary(steps)
+
+    assert summary["schema_version"] == 1
+    assert summary["step_count"] == 2
+    assert summary["requires_user_approval"] is True
+    assert summary["executes"] is False
+    assert summary["consent_actions"] == [
+        ConsentAction.INTERNET_USE.value,
+        ConsentAction.MODEL_DOWNLOAD.value,
+        ConsentAction.MODEL_LOAD.value,
+    ]
+    assert any("download" in title.lower() for title in summary["titles"])
+    assert summary["warnings"]
+
+
+def test_empty_plan_copy_summary_requires_no_approval_and_never_executes():
+    summary = provisioning_plan_copy_summary([])
+
+    assert summary["step_count"] == 0
+    assert summary["requires_user_approval"] is False
+    assert summary["executes"] is False
+    assert summary["consent_actions"] == []


### PR DESCRIPTION
Wave 1B-8 runtime-platform source/design task.

Adds a source-only consent UX copy contract before any future provisioning UI/actions are wired.

Changes:
- ConsentCopy model
- exact copy for each RuntimeConsentPolicy action
- provisioning-plan copy summary
- tests proving wording does not imply hidden execution, silent approval, or automatic continuation

Scope rules preserved:
- no operational provisioning
- no UI action buttons
- no persistence
- no provider mutation
- no model download/load/unload
- no runtime install
- no internet use
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 81 passed in 1.11s

Changed files:
- src/infra/services/runtime_consent_copy.py
- src/tests/test_runtime_consent_copy.py

Related: issue #41, master backlog #24.