### PR TITLE
Add runtime action eligibility presenter

### DIFF
--- a/src/infra/services/runtime_action_eligibility_presenter.py
+++ b/src/infra/services/runtime_action_eligibility_presenter.py
@@ -1,0 +1,106 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Runtime action eligibility presenter.
+
+Converts design-only provisioning plans into UI-safe eligibility rows.
+
+This module never executes provisioning. It only explains:
+- whether future actions are blocked or eligible
+- which consent actions are missing
+- what side effects would occur
+- which consent copy should be shown
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from src.infra.services.runtime_consent import ConsentAction, RuntimeConsentState
+from src.infra.services.runtime_consent_copy import consent_copy_for
+from src.infra.services.runtime_provisioning_contract import (
+    ProvisioningPlanStatus,
+    ProvisioningStep,
+    build_design_only_plan_summary,
+    validate_provisioning_plan,
+)
+
+
+def _display_status(status: ProvisioningPlanStatus) -> str:
+    if status == ProvisioningPlanStatus.ELIGIBLE:
+        return "Eligible after consent"
+    return "Blocked - consent required"
+
+
+def _side_effect_summary(declared_side_effects: Dict[str, bool]) -> List[str]:
+    effects: List[str] = []
+
+    if declared_side_effects.get("internet_used"):
+        effects.append("Uses internet")
+    if declared_side_effects.get("provider_mutated"):
+        effects.append("Changes local provider/runtime state")
+    if declared_side_effects.get("model_download_attempted"):
+        effects.append("Downloads model files")
+    if declared_side_effects.get("model_load_attempted"):
+        effects.append("Loads a model into local runtime")
+    if declared_side_effects.get("model_unload_attempted"):
+        effects.append("Unloads a model from local runtime")
+    if declared_side_effects.get("runtime_install_attempted"):
+        effects.append("Installs runtime components")
+    if declared_side_effects.get("config_mutated"):
+        effects.append("Changes configuration")
+    if declared_side_effects.get("persistence_written"):
+        effects.append("Writes local state")
+    if declared_side_effects.get("project_data_may_leave_machine"):
+        effects.append("Project data may leave this machine")
+
+    return effects or ["No side effects declared"]
+
+
+def present_runtime_action_eligibility(
+    steps: Iterable[ProvisioningStep],
+    consent_state: RuntimeConsentState,
+) -> Dict[str, object]:
+    rows = list(steps or [])
+    validation = validate_provisioning_plan(rows, consent_state)
+    summary = build_design_only_plan_summary(rows)
+
+    missing_actions = list(validation.missing_consent_actions)
+    missing_copy = [consent_copy_for(action).to_dict() for action in missing_actions]
+
+    all_consent_actions = [ConsentAction(action) for action in summary.get("consent_actions_required", [])]
+    consent_rows = [consent_copy_for(action).to_dict() for action in all_consent_actions]
+
+    side_effects = summary.get("declared_side_effects", {})
+    if not isinstance(side_effects, dict):
+        side_effects = {}
+
+    eligible = bool(validation.can_execute)
+
+    return {
+        "schema_version": 1,
+        "status": validation.status.value,
+        "display_status": _display_status(validation.status),
+        "eligible": eligible,
+        "can_execute": False,
+        "executes": False,
+        "execution_message": "This presenter never executes runtime actions.",
+        "step_count": len(rows),
+        "reasons": list(validation.reasons),
+        "missing_consent_actions": [action.value for action in missing_actions],
+        "missing_consent_copy": missing_copy,
+        "consent_copy": consent_rows,
+        "declared_side_effects": dict(side_effects),
+        "side_effect_summary": _side_effect_summary(side_effects),
+        "highest_risk": validation.highest_risk.value,
+        "action_rows": [
+            {
+                "action_type": step.action_type.value,
+                "title": step.title,
+                "target": step.target,
+                "description": step.description,
+                "consent_actions_required": [action.value for action in step.consent_actions_required],
+                "side_effects_declared": step.side_effects_declared.to_dict(),
+            }
+            for step in rows
+        ],
+    }

--- a/src/tests/test_runtime_action_eligibility_presenter.py
+++ b/src/tests/test_runtime_action_eligibility_presenter.py
@@ -1,0 +1,160 @@
+﻿# -*- coding: utf-8 -*-
+"""
+Wave 1B-9: runtime action eligibility presenter tests.
+"""
+
+from src.infra.services.runtime_action_eligibility_presenter import present_runtime_action_eligibility
+from src.infra.services.runtime_consent import ConsentAction, ConsentDecision, ConsentScope, RuntimeConsentState
+from src.infra.services.runtime_provisioning_contract import (
+    ProvisioningActionType,
+    build_provisioning_step,
+)
+
+
+def test_missing_consent_produces_blocked_status_with_copy():
+    state = RuntimeConsentState()
+    step = build_provisioning_step(
+        ProvisioningActionType.MODEL_DOWNLOAD,
+        title="Download model",
+        description="Future model download.",
+        target="balanced-7b-local-q4",
+    )
+
+    out = present_runtime_action_eligibility([step], state)
+
+    assert out["status"] == "blocked"
+    assert out["display_status"] == "Blocked - consent required"
+    assert out["eligible"] is False
+    assert out["can_execute"] is False
+    assert out["executes"] is False
+    assert out["missing_consent_actions"] == [
+        ConsentAction.INTERNET_USE.value,
+        ConsentAction.MODEL_DOWNLOAD.value,
+    ]
+    assert len(out["missing_consent_copy"]) == 2
+    assert any("Download" in row["title"] for row in out["missing_consent_copy"])
+
+
+def test_full_consent_produces_eligible_but_non_executing_status():
+    state = RuntimeConsentState()
+    state.record_decision(ConsentAction.PROVIDER_START, ConsentDecision.APPROVED, scope=ConsentScope.SESSION)
+
+    step = build_provisioning_step(
+        ProvisioningActionType.PROVIDER_START,
+        title="Start local provider",
+        description="Future provider start.",
+        target="lm_studio",
+    )
+
+    out = present_runtime_action_eligibility([step], state)
+
+    assert out["status"] == "eligible"
+    assert out["display_status"] == "Eligible after consent"
+    assert out["eligible"] is True
+    assert out["can_execute"] is False
+    assert out["executes"] is False
+    assert "never executes" in out["execution_message"]
+
+
+def test_side_effect_summary_discloses_download_and_local_write():
+    state = RuntimeConsentState()
+    step = build_provisioning_step(
+        ProvisioningActionType.MODEL_DOWNLOAD,
+        title="Download model",
+        description="Future model download.",
+    )
+
+    out = present_runtime_action_eligibility([step], state)
+
+    assert "Uses internet" in out["side_effect_summary"]
+    assert "Downloads model files" in out["side_effect_summary"]
+    assert "Writes local state" in out["side_effect_summary"]
+
+
+def test_non_local_endpoint_discloses_project_data_boundary_risk():
+    state = RuntimeConsentState()
+    step = build_provisioning_step(
+        ProvisioningActionType.NON_LOCAL_ENDPOINT_ENABLE,
+        title="Use non-local endpoint",
+        description="Future endpoint enablement.",
+        target="https://example.invalid/v1",
+    )
+
+    out = present_runtime_action_eligibility([step], state)
+
+    assert out["highest_risk"] == "high"
+    assert "Project data may leave this machine" in out["side_effect_summary"]
+    assert ConsentAction.NON_LOCAL_ENDPOINT_USE.value in out["missing_consent_actions"]
+
+
+def test_empty_plan_is_blocked_and_non_executing():
+    out = present_runtime_action_eligibility([], RuntimeConsentState())
+
+    assert out["status"] == "blocked"
+    assert out["eligible"] is False
+    assert out["can_execute"] is False
+    assert out["executes"] is False
+    assert out["step_count"] == 0
+    assert "No provisioning steps were supplied." in out["reasons"]
+
+
+def test_output_never_implies_automatic_execution_or_approval():
+    state = RuntimeConsentState()
+    state.record_decision(ConsentAction.MODEL_LOAD, ConsentDecision.APPROVED, scope=ConsentScope.SESSION)
+
+    step = build_provisioning_step(
+        ProvisioningActionType.MODEL_LOAD,
+        title="Load model",
+        description="Future model load.",
+    )
+
+    out = present_runtime_action_eligibility([step], state)
+    text = str(out).lower()
+
+    forbidden = [
+        "automatically approved",
+        "without asking",
+        "silently",
+        "will proceed",
+        "executing now",
+    ]
+
+    for phrase in forbidden:
+        assert phrase not in text
+    assert out["executes"] is False
+    assert out["can_execute"] is False
+
+
+def test_action_rows_include_action_target_and_required_consent():
+    step = build_provisioning_step(
+        ProvisioningActionType.RUNTIME_INSTALL,
+        title="Install runtime",
+        description="Future runtime install.",
+        target="ollama",
+    )
+
+    out = present_runtime_action_eligibility([step], RuntimeConsentState())
+
+    assert out["action_rows"] == [
+        {
+            "action_type": "runtime_install",
+            "title": "Install runtime",
+            "target": "ollama",
+            "description": "Future runtime install.",
+            "consent_actions_required": [
+                ConsentAction.INTERNET_USE.value,
+                ConsentAction.RUNTIME_INSTALL.value,
+            ],
+            "side_effects_declared": {
+                "internet_used": True,
+                "provider_mutated": False,
+                "model_download_attempted": False,
+                "model_load_attempted": False,
+                "model_unload_attempted": False,
+                "runtime_install_attempted": True,
+                "config_mutated": True,
+                "persistence_written": True,
+                "project_data_may_leave_machine": False,
+            },
+        }
+    ]


### PR DESCRIPTION
Wave 1B-9 runtime-platform source task.

Adds a non-executing runtime action eligibility presenter for future provisioning plans.

Changes:
- presenter/view-model for blocked vs eligible runtime action status
- missing-consent summary
- consent copy rows pulled from the consent UX copy contract
- side-effect summary
- action rows for future UI surfaces
- tests proving the presenter remains non-executing and does not imply automatic approval/execution

Scope rules preserved:
- no operational provisioning
- no UI action buttons
- no persistence
- no provider mutation
- no model download/load/unload
- no runtime install
- no internet use
- no packaging changes
- no dependency upgrades

Local Windows verification:
- py_compile passed for changed files
- focused tests passed: 88 passed in 0.49s

Changed files:
- src/infra/services/runtime_action_eligibility_presenter.py
- src/tests/test_runtime_action_eligibility_presenter.py

Related: issue #43, master backlog #24.