### PR TITLE
Add bounded tool registry contract

### DIFF
--- a/src/application/tools/__init__.py
+++ b/src/application/tools/__init__.py
@@ -1,0 +1,4 @@
+﻿"""Tool registry package for bounded SerapeumAI application tools.
+
+This package defines contracts only. It does not execute tools.
+"""

--- a/src/application/tools/tool_registry.py
+++ b/src/application/tools/tool_registry.py
@@ -1,0 +1,331 @@
+﻿"""Bounded tool registry contract for SerapeumAI.
+
+This module defines source-level contracts for future application-owned tools.
+It does not execute tools, route chat, call external services, mutate databases,
+write files, provision runtimes, or perform internet access.
+
+Core doctrine:
+- The LLM may select a tool and propose arguments.
+- The application validates scope, schema, authority, side effects, and consent.
+- The application executes only approved deterministic tools in later packets.
+- The LLM narrates verified tool results.
+- The LLM does not calculate, certify, mutate truth, or silently create memory.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ToolAuthorityLevel(str, Enum):
+    """Authority level for a registered tool."""
+
+    DETERMINISTIC = "deterministic"
+    TRUST_QUERY = "trust_query"
+    SUPPORT_RETRIEVAL = "support_retrieval"
+    AI_SUPPORT = "ai_support"
+    EXTERNAL = "external"
+
+
+class ToolScope(str, Enum):
+    """Scope a tool is allowed to operate within."""
+
+    SESSION = "session"
+    PROJECT = "project"
+    SNAPSHOT = "snapshot"
+    FILE = "file"
+    GLOBAL = "global"
+
+
+class ToolSideEffect(str, Enum):
+    """Declared side effects for a tool.
+
+    Side effects are declarations for governance and validation. This module
+    does not execute side effects.
+    """
+
+    NONE = "none"
+    READ_PROJECT_DB = "read_project_db"
+    READ_GLOBAL_DB = "read_global_db"
+    READ_LOCAL_FILE = "read_local_file"
+    WRITE_PROJECT_DB = "write_project_db"
+    WRITE_LOCAL_FILE = "write_local_file"
+    INTERNET = "internet"
+    MACHINE_STATE = "machine_state"
+    RUNTIME_STATE = "runtime_state"
+
+
+class MemoryCategory(str, Enum):
+    """Separated memory categories.
+
+    Memory is not certified fact and must never silently become governing truth.
+    """
+
+    SESSION = "session"
+    PROJECT = "project"
+    USER_PREFERENCE = "user_preference"
+    RUNTIME_DIAGNOSTIC = "runtime_diagnostic"
+    CERTIFIED_FACT = "certified_fact"
+
+
+class ToolContractError(ValueError):
+    """Raised when a tool definition violates the registry contract."""
+
+
+MUTATING_SIDE_EFFECTS = {
+    ToolSideEffect.WRITE_PROJECT_DB,
+    ToolSideEffect.WRITE_LOCAL_FILE,
+    ToolSideEffect.INTERNET,
+    ToolSideEffect.MACHINE_STATE,
+    ToolSideEffect.RUNTIME_STATE,
+}
+
+READ_SIDE_EFFECTS = {
+    ToolSideEffect.READ_PROJECT_DB,
+    ToolSideEffect.READ_GLOBAL_DB,
+    ToolSideEffect.READ_LOCAL_FILE,
+}
+
+
+@dataclass(frozen=True)
+class ToolDefinition:
+    """Source-defined metadata for one future application tool."""
+
+    tool_id: str
+    display_name: str
+    description: str
+    input_schema: Mapping[str, Any]
+    output_schema: Mapping[str, Any]
+    authority_level: ToolAuthorityLevel
+    scope: ToolScope
+    side_effects: tuple[ToolSideEffect, ...] = (ToolSideEffect.NONE,)
+    requires_consent: bool = False
+    can_govern_truth: bool = False
+    audit_log_required: bool = True
+    enabled_by_default: bool = False
+    requires_project: bool = False
+    requires_snapshot: bool = False
+    result_provenance_required: bool = False
+    version: str = "1.0"
+
+    def validate(self) -> None:
+        validate_tool_definition(self)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "display_name": self.display_name,
+            "description": self.description,
+            "input_schema": dict(self.input_schema),
+            "output_schema": dict(self.output_schema),
+            "authority_level": self.authority_level.value,
+            "scope": self.scope.value,
+            "side_effects": [item.value for item in self.side_effects],
+            "requires_consent": self.requires_consent,
+            "can_govern_truth": self.can_govern_truth,
+            "audit_log_required": self.audit_log_required,
+            "enabled_by_default": self.enabled_by_default,
+            "requires_project": self.requires_project,
+            "requires_snapshot": self.requires_snapshot,
+            "result_provenance_required": self.result_provenance_required,
+            "version": self.version,
+        }
+
+
+@dataclass(frozen=True)
+class ToolResultEnvelope:
+    """Standard future result envelope for verified tool results."""
+
+    tool_id: str
+    ok: bool
+    result: Mapping[str, Any] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    provenance: tuple[Mapping[str, Any], ...] = ()
+    can_govern_truth: bool = False
+    authority_level: ToolAuthorityLevel = ToolAuthorityLevel.SUPPORT_RETRIEVAL
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "ok": self.ok,
+            "result": dict(self.result),
+            "warnings": list(self.warnings),
+            "provenance": [dict(item) for item in self.provenance],
+            "can_govern_truth": self.can_govern_truth,
+            "authority_level": self.authority_level.value,
+        }
+
+
+def normalize_enum(value: Any, enum_type: type[Enum], field_name: str) -> Enum:
+    if isinstance(value, enum_type):
+        return value
+    try:
+        return enum_type(value)
+    except Exception as exc:
+        allowed = ", ".join(item.value for item in enum_type)
+        raise ToolContractError(
+            f"Invalid {field_name}: {value!r}. Allowed values: {allowed}"
+        ) from exc
+
+
+def normalize_side_effects(values: Any) -> tuple[ToolSideEffect, ...]:
+    if values is None:
+        return (ToolSideEffect.NONE,)
+    if isinstance(values, ToolSideEffect):
+        raw_values = (values,)
+    elif isinstance(values, str):
+        raise ToolContractError(
+            "side_effects must use ToolSideEffect instances, not strings."
+        )
+    else:
+        raw_values = tuple(values)
+
+    effects = []
+    for value in raw_values:
+        require_enum_instance(value, ToolSideEffect, "side_effects")
+        effects.append(value)
+
+    if not effects:
+        return (ToolSideEffect.NONE,)
+
+    normalized = tuple(effects)
+
+    if ToolSideEffect.NONE in normalized and len(normalized) > 1:
+        raise ToolContractError("side_effects cannot mix NONE with other effects.")
+
+    return normalized
+
+
+def validate_json_schema_like(schema: Mapping[str, Any], field_name: str) -> None:
+    if not isinstance(schema, Mapping):
+        raise ToolContractError(f"{field_name} must be a mapping.")
+    schema_type = schema.get("type")
+    if schema_type is None:
+        raise ToolContractError(f"{field_name} must include a 'type' field.")
+    if not isinstance(schema_type, str):
+        raise ToolContractError(f"{field_name}.type must be a string.")
+
+
+def require_enum_instance(value: Any, enum_type: type[Enum], field_name: str) -> None:
+    """Require source-defined contracts to use enum instances, not strings.
+
+    String/JSON loading can be added later in a dedicated loader. The registry
+    contract itself must not accept values that later fail serialization.
+    """
+
+    if not isinstance(value, enum_type):
+        allowed = ", ".join(item.value for item in enum_type)
+        raise ToolContractError(
+            f"{field_name} must be a {enum_type.__name__} instance. "
+            f"Allowed values: {allowed}"
+        )
+
+
+def validate_tool_definition(tool: ToolDefinition) -> None:
+    if not tool.tool_id or not tool.tool_id.strip():
+        raise ToolContractError("tool_id is required.")
+    if " " in tool.tool_id:
+        raise ToolContractError("tool_id must be stable and must not contain spaces.")
+    if not tool.display_name.strip():
+        raise ToolContractError("display_name is required.")
+    if not tool.description.strip():
+        raise ToolContractError("description is required.")
+
+    validate_json_schema_like(tool.input_schema, "input_schema")
+    validate_json_schema_like(tool.output_schema, "output_schema")
+
+    require_enum_instance(tool.authority_level, ToolAuthorityLevel, "authority_level")
+    require_enum_instance(tool.scope, ToolScope, "scope")
+    side_effects = normalize_side_effects(tool.side_effects)
+
+    if tool.enabled_by_default and any(effect in MUTATING_SIDE_EFFECTS for effect in side_effects):
+        raise ToolContractError(
+            "Tools with mutating, internet, machine, or runtime side effects "
+            "must not be enabled by default."
+        )
+
+    if any(effect in MUTATING_SIDE_EFFECTS for effect in side_effects) and not tool.requires_consent:
+        raise ToolContractError("Side-effectful tools must require consent.")
+
+    if tool.authority_level in {ToolAuthorityLevel.AI_SUPPORT, ToolAuthorityLevel.EXTERNAL}:
+        if tool.can_govern_truth:
+            raise ToolContractError("AI_SUPPORT and EXTERNAL tools cannot govern truth.")
+
+    if tool.can_govern_truth and tool.authority_level not in {
+        ToolAuthorityLevel.DETERMINISTIC,
+        ToolAuthorityLevel.TRUST_QUERY,
+    }:
+        raise ToolContractError(
+            "Only deterministic or trust-query tools may govern truth."
+        )
+
+    if tool.can_govern_truth and not tool.result_provenance_required:
+        raise ToolContractError("Truth-governing tools require result provenance.")
+
+    if tool.scope in {ToolScope.PROJECT, ToolScope.SNAPSHOT, ToolScope.FILE}:
+        if not tool.requires_project:
+            raise ToolContractError(
+                "Project, snapshot, and file scoped tools must require a project."
+            )
+
+    if tool.scope == ToolScope.SNAPSHOT and not tool.requires_snapshot:
+        raise ToolContractError("Snapshot-scoped tools must require a snapshot.")
+
+
+def validate_tool_registry(tools: Mapping[str, ToolDefinition]) -> None:
+    if not isinstance(tools, Mapping):
+        raise ToolContractError("tool registry must be a mapping.")
+
+    for key, tool in tools.items():
+        if key != tool.tool_id:
+            raise ToolContractError(
+                f"Registry key {key!r} must match tool_id {tool.tool_id!r}."
+            )
+        tool.validate()
+
+
+def calculation_doctrine() -> dict[str, Any]:
+    """Return deterministic calculation doctrine for future tool packets."""
+
+    return {
+        "llm_may_calculate": False,
+        "application_must_calculate": True,
+        "required_result_fields": [
+            "formula_or_operation",
+            "normalized_inputs",
+            "units",
+            "source_references",
+            "computed_result",
+            "rounding_policy",
+            "warnings",
+            "tool_id",
+            "tool_version",
+        ],
+    }
+
+
+def memory_separation_doctrine() -> dict[str, Any]:
+    """Return memory separation doctrine for future tool/memory packets."""
+
+    return {
+        "memory_can_be_certified_fact_silently": False,
+        "project_memory_can_cross_projects": False,
+        "user_preferences_can_answer_project_facts": False,
+        "runtime_diagnostics_can_govern_engineering_truth": False,
+        "persistent_memory_requires_explicit_audit_design": True,
+        "categories": [item.value for item in MemoryCategory],
+    }
+
+
+FUTURE_SAFE_TOOL_CANDIDATES: tuple[str, ...] = (
+    "calculator",
+    "unit_conversion",
+    "quantity_formula",
+    "fact_query",
+    "evidence_retrieval",
+    "schedule_query",
+    "metadata_inspection",
+    "register_table_comparison",
+)

--- a/src/tests/test_tool_registry_contract.py
+++ b/src/tests/test_tool_registry_contract.py
@@ -1,0 +1,182 @@
+﻿from __future__ import annotations
+
+import pytest
+
+from src.application.tools.tool_registry import (
+    FUTURE_SAFE_TOOL_CANDIDATES,
+    MemoryCategory,
+    ToolAuthorityLevel,
+    ToolContractError,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+    calculation_doctrine,
+    memory_separation_doctrine,
+    normalize_side_effects,
+    validate_tool_registry,
+)
+
+
+def valid_tool(**overrides):
+    data = {
+        "tool_id": "calculator.local",
+        "display_name": "Local Calculator",
+        "description": "Performs deterministic local arithmetic.",
+        "input_schema": {"type": "object", "properties": {}},
+        "output_schema": {"type": "object", "properties": {}},
+        "authority_level": ToolAuthorityLevel.DETERMINISTIC,
+        "scope": ToolScope.SESSION,
+        "side_effects": (ToolSideEffect.NONE,),
+        "requires_consent": False,
+        "can_govern_truth": False,
+        "audit_log_required": True,
+        "enabled_by_default": False,
+        "requires_project": False,
+        "requires_snapshot": False,
+        "result_provenance_required": False,
+    }
+    data.update(overrides)
+    return ToolDefinition(**data)
+
+
+def test_valid_deterministic_tool_definition_passes():
+    tool = valid_tool()
+    tool.validate()
+
+    out = tool.to_dict()
+    assert out["tool_id"] == "calculator.local"
+    assert out["authority_level"] == "deterministic"
+    assert out["side_effects"] == ["none"]
+
+
+def test_registry_key_must_match_tool_id():
+    with pytest.raises(ToolContractError):
+        validate_tool_registry({"wrong.key": valid_tool()})
+
+
+def test_string_authority_value_is_rejected_even_when_value_is_known():
+    tool = valid_tool(authority_level="deterministic")
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_unknown_authority_value_is_rejected():
+    tool = valid_tool(authority_level="bad-authority")
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_string_side_effect_value_is_rejected_even_when_value_is_known():
+    with pytest.raises(ToolContractError):
+        normalize_side_effects(("internet",))
+
+
+def test_unknown_side_effect_value_is_rejected():
+    with pytest.raises(ToolContractError):
+        normalize_side_effects(("bad-effect",))
+
+
+def test_none_side_effect_cannot_mix_with_other_effects():
+    with pytest.raises(ToolContractError):
+        normalize_side_effects((ToolSideEffect.NONE, ToolSideEffect.READ_PROJECT_DB))
+
+
+def test_side_effectful_tool_requires_consent():
+    tool = valid_tool(
+        side_effects=(ToolSideEffect.WRITE_PROJECT_DB,),
+        requires_consent=False,
+    )
+
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_side_effectful_tool_cannot_be_enabled_by_default():
+    tool = valid_tool(
+        side_effects=(ToolSideEffect.INTERNET,),
+        requires_consent=True,
+        enabled_by_default=True,
+    )
+
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_ai_support_and_external_tools_cannot_govern_truth():
+    for authority in (ToolAuthorityLevel.AI_SUPPORT, ToolAuthorityLevel.EXTERNAL):
+        tool = valid_tool(
+            authority_level=authority,
+            can_govern_truth=True,
+            result_provenance_required=True,
+        )
+        with pytest.raises(ToolContractError):
+            tool.validate()
+
+
+def test_truth_governing_tool_requires_allowed_authority_and_provenance():
+    without_provenance = valid_tool(
+        authority_level=ToolAuthorityLevel.TRUST_QUERY,
+        can_govern_truth=True,
+        result_provenance_required=False,
+    )
+    with pytest.raises(ToolContractError):
+        without_provenance.validate()
+
+    with_provenance = valid_tool(
+        authority_level=ToolAuthorityLevel.TRUST_QUERY,
+        can_govern_truth=True,
+        result_provenance_required=True,
+        scope=ToolScope.PROJECT,
+        requires_project=True,
+        side_effects=(ToolSideEffect.READ_PROJECT_DB,),
+    )
+    with_provenance.validate()
+
+
+def test_project_snapshot_and_file_scoped_tools_require_project():
+    for scope in (ToolScope.PROJECT, ToolScope.SNAPSHOT, ToolScope.FILE):
+        tool = valid_tool(scope=scope, requires_project=False)
+        with pytest.raises(ToolContractError):
+            tool.validate()
+
+
+def test_snapshot_scoped_tools_require_snapshot():
+    tool = valid_tool(
+        scope=ToolScope.SNAPSHOT,
+        requires_project=True,
+        requires_snapshot=False,
+    )
+
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_json_schema_like_contract_requires_type_field():
+    tool = valid_tool(input_schema={"properties": {}})
+    with pytest.raises(ToolContractError):
+        tool.validate()
+
+
+def test_calculation_doctrine_forbids_llm_arithmetic():
+    doctrine = calculation_doctrine()
+
+    assert doctrine["llm_may_calculate"] is False
+    assert doctrine["application_must_calculate"] is True
+    assert "formula_or_operation" in doctrine["required_result_fields"]
+    assert "computed_result" in doctrine["required_result_fields"]
+    assert "rounding_policy" in doctrine["required_result_fields"]
+
+
+def test_memory_separation_doctrine_blocks_memory_as_truth():
+    doctrine = memory_separation_doctrine()
+
+    assert doctrine["memory_can_be_certified_fact_silently"] is False
+    assert doctrine["project_memory_can_cross_projects"] is False
+    assert doctrine["runtime_diagnostics_can_govern_engineering_truth"] is False
+    assert MemoryCategory.CERTIFIED_FACT.value in doctrine["categories"]
+
+
+def test_future_safe_tool_candidates_are_declared_without_execution():
+    assert "calculator" in FUTURE_SAFE_TOOL_CANDIDATES
+    assert "fact_query" in FUTURE_SAFE_TOOL_CANDIDATES
+    assert "schedule_query" in FUTURE_SAFE_TOOL_CANDIDATES


### PR DESCRIPTION
## Summary

Adds the first bounded Tool Registry contract for Upgrade 1B-0.

This defines source-level contracts for future application-owned tools without wiring broad tool execution, autonomous chat-agent loops, internet tools, file writes, provider provisioning, runtime actions, persistent consent, or truth mutation.

## Scope

Added:

- `src/application/tools/__init__.py`
- `src/application/tools/tool_registry.py`
- `src/tests/test_tool_registry_contract.py`

## What this provides

- Tool authority levels
- Tool scope vocabulary
- Tool side-effect classes
- Tool definition contract
- Tool result envelope contract
- Registry validation helper
- Deterministic calculation doctrine
- Memory separation doctrine
- Future safe tool candidate list
- Contract tests proving strict validation behavior

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\tests\test_tool_registry_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_runtime_action_eligibility_presenter.py
22 passed in 0.06s
```

Staged packaging check:

```text
git diff --cached --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

Staged diff health:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No packaging changes
- No dependency upgrades
- No broad tool execution router
- No chat-agent autonomous loop
- No MCP integration
- No internet tools
- No file write tools
- No provider provisioning
- No runtime install/download/start/stop/load/unload
- No persistent consent implementation
- No source-of-truth mutation
- No candidate fact certification by tool

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: controlled by non-executing contract/tests

Related: issue #48.