### PR TITLE
Add deterministic calculator tool contract

### DIFF
--- a/src/application/tools/calculator_tool.py
+++ b/src/application/tools/calculator_tool.py
@@ -1,0 +1,206 @@
+﻿"""Deterministic local calculator tool for SerapeumAI.
+
+This module performs local arithmetic only. It does not call an LLM, provider,
+database, filesystem, internet endpoint, runtime manager, or UI surface.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, DivisionByZero, InvalidOperation, getcontext
+from typing import Any, Iterable
+
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+)
+
+TOOL_ID = "calculator.local"
+TOOL_VERSION = "1.0"
+ROUNDING_POLICY = "Decimal arithmetic; result serialized as plain decimal string; no display rounding applied."
+SUPPORTED_OPERATIONS = {"add", "subtract", "multiply", "divide", "power", "sum", "average"}
+
+# Enough precision for normal engineering-support arithmetic without introducing
+# floating-point nondeterminism. This is not a units or quantity engine.
+getcontext().prec = 28
+
+
+class CalculatorToolError(ValueError):
+    """Raised when calculator input is invalid or operation cannot be performed."""
+
+
+def calculator_tool_definition() -> ToolDefinition:
+    """Return the source-defined non-mutating calculator tool definition."""
+
+    definition = ToolDefinition(
+        tool_id=TOOL_ID,
+        display_name="Local Calculator",
+        description="Performs deterministic local arithmetic without LLM involvement.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "operation": {"type": "string"},
+                "inputs": {"type": "array"},
+            },
+            "required": ["operation", "inputs"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "operation": {"type": "string"},
+                "normalized_inputs": {"type": "array"},
+                "computed_result": {"type": "string"},
+                "rounding_policy": {"type": "string"},
+                "warnings": {"type": "array"},
+                "tool_id": {"type": "string"},
+                "tool_version": {"type": "string"},
+                "formula_or_operation": {"type": "string"},
+                "units": {"type": "string"},
+                "can_govern_truth": {"type": "boolean"},
+            },
+            "required": [
+                "operation",
+                "normalized_inputs",
+                "computed_result",
+                "rounding_policy",
+                "warnings",
+                "tool_id",
+                "tool_version",
+                "formula_or_operation",
+                "units",
+                "can_govern_truth",
+            ],
+        },
+        authority_level=ToolAuthorityLevel.DETERMINISTIC,
+        scope=ToolScope.SESSION,
+        side_effects=(ToolSideEffect.NONE,),
+        requires_consent=False,
+        can_govern_truth=False,
+        audit_log_required=True,
+        enabled_by_default=True,
+        requires_project=False,
+        requires_snapshot=False,
+        result_provenance_required=False,
+    )
+    definition.validate()
+    return definition
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, bool):
+        raise CalculatorToolError("Boolean values are not valid calculator inputs.")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise CalculatorToolError("NaN and infinity are not valid calculator inputs.")
+        return Decimal(str(value))
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise CalculatorToolError("Empty strings are not valid calculator inputs.")
+        try:
+            return Decimal(stripped)
+        except InvalidOperation as exc:
+            raise CalculatorToolError(f"Non-numeric input: {value!r}") from exc
+
+    raise CalculatorToolError(f"Unsupported input type: {type(value).__name__}")
+
+
+def _normalize_inputs(inputs: Iterable[Any]) -> tuple[Decimal, ...]:
+    try:
+        normalized = tuple(_to_decimal(value) for value in inputs)
+    except TypeError as exc:
+        raise CalculatorToolError("inputs must be an iterable of numeric values.") from exc
+
+    if not normalized:
+        raise CalculatorToolError("At least one numeric input is required.")
+    return normalized
+
+
+def _require_count(operation: str, values: tuple[Decimal, ...], count: int) -> None:
+    if len(values) != count:
+        raise CalculatorToolError(f"{operation} requires exactly {count} inputs.")
+
+
+def _decimal_to_string(value: Decimal) -> str:
+    if value == value.to_integral_value():
+        return str(value.quantize(Decimal(1)))
+    return format(value.normalize(), "f")
+
+
+def _formula(operation: str, values: tuple[Decimal, ...]) -> str:
+    serialized = [_decimal_to_string(value) for value in values]
+    if operation == "add":
+        return " + ".join(serialized)
+    if operation == "subtract":
+        return f"{serialized[0]} - {serialized[1]}"
+    if operation == "multiply":
+        return " * ".join(serialized)
+    if operation == "divide":
+        return f"{serialized[0]} / {serialized[1]}"
+    if operation == "power":
+        return f"{serialized[0]} ^ {serialized[1]}"
+    if operation == "sum":
+        return "sum(" + ", ".join(serialized) + ")"
+    if operation == "average":
+        return "average(" + ", ".join(serialized) + ")"
+    return operation
+
+
+def calculate(operation: str, inputs: Iterable[Any]) -> dict[str, Any]:
+    """Perform deterministic local arithmetic and return a governed envelope."""
+
+    if not isinstance(operation, str) or not operation.strip():
+        raise CalculatorToolError("operation must be a non-empty string.")
+
+    normalized_operation = operation.strip().lower()
+    if normalized_operation not in SUPPORTED_OPERATIONS:
+        raise CalculatorToolError(f"Unsupported operation: {operation!r}")
+
+    values = _normalize_inputs(inputs)
+
+    try:
+        if normalized_operation == "add":
+            _require_count(normalized_operation, values, 2)
+            result = values[0] + values[1]
+        elif normalized_operation == "subtract":
+            _require_count(normalized_operation, values, 2)
+            result = values[0] - values[1]
+        elif normalized_operation == "multiply":
+            _require_count(normalized_operation, values, 2)
+            result = values[0] * values[1]
+        elif normalized_operation == "divide":
+            _require_count(normalized_operation, values, 2)
+            if values[1] == 0:
+                raise CalculatorToolError("Division by zero is not allowed.")
+            result = values[0] / values[1]
+        elif normalized_operation == "power":
+            _require_count(normalized_operation, values, 2)
+            result = values[0] ** values[1]
+        elif normalized_operation == "sum":
+            result = sum(values, Decimal(0))
+        elif normalized_operation == "average":
+            result = sum(values, Decimal(0)) / Decimal(len(values))
+        else:
+            raise CalculatorToolError(f"Unsupported operation: {operation!r}")
+    except DivisionByZero as exc:
+        raise CalculatorToolError("Division by zero is not allowed.") from exc
+    except InvalidOperation as exc:
+        raise CalculatorToolError(f"Invalid calculation for operation: {operation!r}") from exc
+
+    return {
+        "operation": normalized_operation,
+        "normalized_inputs": [_decimal_to_string(value) for value in values],
+        "computed_result": _decimal_to_string(result),
+        "rounding_policy": ROUNDING_POLICY,
+        "warnings": [],
+        "tool_id": TOOL_ID,
+        "tool_version": TOOL_VERSION,
+        "formula_or_operation": _formula(normalized_operation, values),
+        "units": "dimensionless",
+        "can_govern_truth": False,
+    }

--- a/src/tests/test_calculator_tool_contract.py
+++ b/src/tests/test_calculator_tool_contract.py
@@ -1,0 +1,116 @@
+﻿from __future__ import annotations
+
+import pytest
+
+from src.application.tools.calculator_tool import (
+    TOOL_ID,
+    CalculatorToolError,
+    calculate,
+    calculator_tool_definition,
+)
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolScope,
+    ToolSideEffect,
+)
+
+
+def test_calculator_tool_definition_validates_against_registry_contract():
+    definition = calculator_tool_definition()
+
+    assert definition.tool_id == TOOL_ID
+    assert definition.authority_level == ToolAuthorityLevel.DETERMINISTIC
+    assert definition.scope == ToolScope.SESSION
+    assert definition.side_effects == (ToolSideEffect.NONE,)
+    assert definition.can_govern_truth is False
+    assert definition.enabled_by_default is True
+    assert definition.requires_project is False
+    assert definition.requires_snapshot is False
+
+    definition.validate()
+
+
+@pytest.mark.parametrize(
+    ("operation", "inputs", "expected"),
+    [
+        ("add", [2, 3], "5"),
+        ("subtract", [10, 4], "6"),
+        ("multiply", [6, 7], "42"),
+        ("divide", [22, 7], "3.142857142857142857142857143"),
+        ("power", [2, 8], "256"),
+        ("sum", [1, 2, 3, 4], "10"),
+        ("average", [2, 4, 6], "4"),
+    ],
+)
+def test_calculator_operations_are_deterministic(operation, inputs, expected):
+    first = calculate(operation, inputs)
+    second = calculate(operation, inputs)
+
+    assert first == second
+    assert first["computed_result"] == expected
+    assert first["operation"] == operation
+    assert first["tool_id"] == TOOL_ID
+    assert first["tool_version"] == "1.0"
+    assert first["units"] == "dimensionless"
+    assert first["can_govern_truth"] is False
+    assert first["warnings"] == []
+    assert "rounding_policy" in first
+    assert "formula_or_operation" in first
+    assert first["normalized_inputs"] == [str(item) for item in inputs]
+
+
+def test_string_numeric_inputs_are_normalized_deterministically():
+    result = calculate("add", ["2.50", "3.25"])
+
+    assert result["normalized_inputs"] == ["2.5", "3.25"]
+    assert result["computed_result"] == "5.75"
+
+
+def test_operation_is_case_and_whitespace_normalized():
+    result = calculate(" DIVIDE ", ["10", "4"])
+
+    assert result["operation"] == "divide"
+    assert result["computed_result"] == "2.5"
+
+
+def test_division_by_zero_is_controlled():
+    with pytest.raises(CalculatorToolError, match="Division by zero"):
+        calculate("divide", [1, 0])
+
+
+def test_invalid_operation_is_controlled():
+    with pytest.raises(CalculatorToolError, match="Unsupported operation"):
+        calculate("sqrt", [4])
+
+
+@pytest.mark.parametrize("bad_input", ["abc", "", True, object()])
+def test_non_numeric_inputs_are_rejected(bad_input):
+    with pytest.raises(CalculatorToolError):
+        calculate("add", [1, bad_input])
+
+
+def test_empty_inputs_are_rejected():
+    with pytest.raises(CalculatorToolError, match="At least one numeric input"):
+        calculate("sum", [])
+
+
+def test_binary_operations_require_exactly_two_inputs():
+    with pytest.raises(CalculatorToolError, match="requires exactly 2 inputs"):
+        calculate("add", [1, 2, 3])
+
+
+def test_inputs_must_be_iterable():
+    with pytest.raises(CalculatorToolError, match="inputs must be an iterable"):
+        calculate("add", None)
+
+
+def test_calculator_has_no_llm_provider_internet_file_db_or_runtime_dependency():
+    definition = calculator_tool_definition()
+
+    assert definition.side_effects == (ToolSideEffect.NONE,)
+    assert definition.requires_consent is False
+    assert definition.can_govern_truth is False
+
+    result = calculate("multiply", [3, 5])
+    assert result["computed_result"] == "15"
+    assert result["can_govern_truth"] is False


### PR DESCRIPTION
## Summary

Adds the first deterministic local tool under the Tool Registry contract: a calculator tool contract that performs application-owned arithmetic and returns governed results.

This reinforces the owner rule: the application calculates locally; the LLM does not calculate.

## Scope

Added:

- `src/application/tools/calculator_tool.py`
- `src/tests/test_calculator_tool_contract.py`

## What this provides

- Source-defined calculator tool definition using the existing Tool Registry contract
- Deterministic Decimal-based arithmetic
- Basic operations: add, subtract, multiply, divide, power, sum, average
- Strict input validation
- Controlled division-by-zero and invalid-operation errors
- Governed result envelope with operation, normalized inputs, computed result, rounding policy, tool ID/version, formula/operation, units, warnings, and `can_govern_truth=false`
- Tests proving deterministic behavior and non-mutating/no-runtime/no-provider posture

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\calculator_tool.py src\tests\test_calculator_tool_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_calculator_tool_contract.py
37 passed in 0.08s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No internet use
- No file writes
- No DB writes
- No source-of-truth mutation
- No candidate fact certification
- No unit-conversion tool
- No quantity/formula engine
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; no router/chat execution added
- Product risk: reduced by deterministic local calculation doctrine

Related: issue #50.