### PR TITLE
Add deterministic quantity formula tool contract

### DIFF
--- a/src/application/tools/quantity_formula_tool.py
+++ b/src/application/tools/quantity_formula_tool.py
@@ -1,0 +1,258 @@
+﻿"""Deterministic local quantity/formula tool for SerapeumAI.
+
+This module evaluates a narrow set of explicit AECO-safe formulas only.
+It does not parse arbitrary formulas, call an LLM, provider, database,
+filesystem, internet endpoint, runtime manager, or UI surface.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation, getcontext
+from typing import Any, Mapping
+
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+)
+
+TOOL_ID = "quantity_formula.local"
+TOOL_VERSION = "1.0"
+ROUNDING_POLICY = "Decimal arithmetic; result serialized as plain decimal string; no display rounding applied."
+
+getcontext().prec = 28
+
+
+class QuantityFormulaToolError(ValueError):
+    """Raised when formula input is invalid or unsupported."""
+
+
+FORMULA_CONTRACTS: dict[str, dict[str, Any]] = {
+    "rectangle_area": {
+        "required": ("length", "width"),
+        "formula": "area = length * width",
+        "result_unit": "derived_area",
+        "physical_dimensions": True,
+    },
+    "room_volume": {
+        "required": ("length", "width", "height"),
+        "formula": "volume = length * width * height",
+        "result_unit": "derived_volume",
+        "physical_dimensions": True,
+    },
+    "concrete_volume": {
+        "required": ("length", "width", "thickness"),
+        "formula": "volume = length * width * thickness",
+        "result_unit": "derived_volume",
+        "physical_dimensions": True,
+    },
+    "percentage_ratio": {
+        "required": ("part", "whole"),
+        "formula": "percentage = part / whole * 100",
+        "result_unit": "percent",
+        "physical_dimensions": False,
+    },
+    "progress_ratio": {
+        "required": ("completed", "total"),
+        "formula": "progress = completed / total * 100",
+        "result_unit": "percent",
+        "physical_dimensions": False,
+    },
+    "density_mass": {
+        "required": ("density", "volume"),
+        "formula": "mass = density * volume",
+        "result_unit": "derived_mass",
+        "physical_dimensions": True,
+    },
+    "linear_weight": {
+        "required": ("unit_weight", "length"),
+        "formula": "weight = unit_weight * length",
+        "result_unit": "derived_weight",
+        "physical_dimensions": True,
+    },
+    "circle_area": {
+        "required": ("radius",),
+        "formula": "area = pi * radius ^ 2",
+        "result_unit": "derived_area",
+        "physical_dimensions": True,
+    },
+}
+
+PI = Decimal("3.141592653589793238462643383")
+
+
+def quantity_formula_tool_definition() -> ToolDefinition:
+    """Return the source-defined non-mutating quantity/formula tool definition."""
+
+    definition = ToolDefinition(
+        tool_id=TOOL_ID,
+        display_name="Local Quantity Formula",
+        description="Evaluates supported AECO-safe quantity formulas deterministically without LLM involvement.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "formula_id": {"type": "string"},
+                "inputs": {"type": "object"},
+            },
+            "required": ["formula_id", "inputs"],
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "operation": {"type": "string"},
+                "formula_id": {"type": "string"},
+                "formula_or_operation": {"type": "string"},
+                "normalized_inputs": {"type": "object"},
+                "computed_result": {"type": "string"},
+                "result_unit": {"type": "string"},
+                "rounding_policy": {"type": "string"},
+                "warnings": {"type": "array"},
+                "tool_id": {"type": "string"},
+                "tool_version": {"type": "string"},
+                "can_govern_truth": {"type": "boolean"},
+            },
+            "required": [
+                "operation",
+                "formula_id",
+                "formula_or_operation",
+                "normalized_inputs",
+                "computed_result",
+                "result_unit",
+                "rounding_policy",
+                "warnings",
+                "tool_id",
+                "tool_version",
+                "can_govern_truth",
+            ],
+        },
+        authority_level=ToolAuthorityLevel.DETERMINISTIC,
+        scope=ToolScope.SESSION,
+        side_effects=(ToolSideEffect.NONE,),
+        requires_consent=False,
+        can_govern_truth=False,
+        audit_log_required=True,
+        enabled_by_default=True,
+        requires_project=False,
+        requires_snapshot=False,
+        result_provenance_required=False,
+    )
+    definition.validate()
+    return definition
+
+
+def _to_decimal(value: Any, field_name: str) -> Decimal:
+    if isinstance(value, bool):
+        raise QuantityFormulaToolError(f"Boolean value is not valid for {field_name}.")
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, int):
+        return Decimal(value)
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise QuantityFormulaToolError(f"NaN and infinity are not valid for {field_name}.")
+        return Decimal(str(value))
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            raise QuantityFormulaToolError(f"Empty string is not valid for {field_name}.")
+        try:
+            return Decimal(stripped)
+        except InvalidOperation as exc:
+            raise QuantityFormulaToolError(f"Non-numeric input for {field_name}: {value!r}") from exc
+    raise QuantityFormulaToolError(f"Unsupported input type for {field_name}: {type(value).__name__}")
+
+
+def _decimal_to_string(value: Decimal) -> str:
+    if value == value.to_integral_value():
+        return str(value.quantize(Decimal(1)))
+    return format(value.normalize(), "f")
+
+
+def _normalize_formula_id(formula_id: str) -> str:
+    if not isinstance(formula_id, str) or not formula_id.strip():
+        raise QuantityFormulaToolError("formula_id must be a non-empty string.")
+    normalized = formula_id.strip().lower()
+    if normalized not in FORMULA_CONTRACTS:
+        raise QuantityFormulaToolError(f"Unsupported formula: {formula_id!r}")
+    return normalized
+
+
+def _normalize_inputs(formula_id: str, inputs: Mapping[str, Any]) -> tuple[dict[str, Decimal], list[str]]:
+    if not isinstance(inputs, Mapping):
+        raise QuantityFormulaToolError("inputs must be a mapping.")
+
+    contract = FORMULA_CONTRACTS[formula_id]
+    required = contract["required"]
+    missing = [name for name in required if name not in inputs]
+    if missing:
+        raise QuantityFormulaToolError(f"Missing required input(s): {', '.join(missing)}")
+
+    extra = sorted(name for name in inputs if name not in required)
+    if extra:
+        raise QuantityFormulaToolError(f"Unsupported extra input(s): {', '.join(extra)}")
+
+    normalized = {name: _to_decimal(inputs[name], name) for name in required}
+
+    if contract["physical_dimensions"]:
+        for name, value in normalized.items():
+            if value < 0:
+                raise QuantityFormulaToolError(f"Negative physical dimension/value is not allowed for {name}.")
+
+    if formula_id in {"percentage_ratio", "progress_ratio"}:
+        for name, value in normalized.items():
+            if value < 0:
+                raise QuantityFormulaToolError(f"Negative ratio input is not allowed for {name}.")
+
+    return normalized, []
+
+
+def _compute(formula_id: str, values: Mapping[str, Decimal]) -> Decimal:
+    if formula_id == "rectangle_area":
+        return values["length"] * values["width"]
+    if formula_id == "room_volume":
+        return values["length"] * values["width"] * values["height"]
+    if formula_id == "concrete_volume":
+        return values["length"] * values["width"] * values["thickness"]
+    if formula_id == "percentage_ratio":
+        if values["whole"] == 0:
+            raise QuantityFormulaToolError("Division by zero is not allowed for percentage_ratio.")
+        return values["part"] / values["whole"] * Decimal("100")
+    if formula_id == "progress_ratio":
+        if values["total"] == 0:
+            raise QuantityFormulaToolError("Division by zero is not allowed for progress_ratio.")
+        return values["completed"] / values["total"] * Decimal("100")
+    if formula_id == "density_mass":
+        return values["density"] * values["volume"]
+    if formula_id == "linear_weight":
+        return values["unit_weight"] * values["length"]
+    if formula_id == "circle_area":
+        return PI * values["radius"] * values["radius"]
+
+    raise QuantityFormulaToolError(f"Unsupported formula: {formula_id!r}")
+
+
+def evaluate_formula(formula_id: str, inputs: Mapping[str, Any]) -> dict[str, Any]:
+    """Evaluate a supported quantity formula and return a governed envelope."""
+
+    normalized_formula_id = _normalize_formula_id(formula_id)
+    normalized_inputs, warnings = _normalize_inputs(normalized_formula_id, inputs)
+    result = _compute(normalized_formula_id, normalized_inputs)
+    contract = FORMULA_CONTRACTS[normalized_formula_id]
+
+    return {
+        "operation": "quantity_formula",
+        "formula_id": normalized_formula_id,
+        "formula_or_operation": contract["formula"],
+        "normalized_inputs": {
+            name: _decimal_to_string(value)
+            for name, value in normalized_inputs.items()
+        },
+        "computed_result": _decimal_to_string(result),
+        "result_unit": contract["result_unit"],
+        "rounding_policy": ROUNDING_POLICY,
+        "warnings": warnings,
+        "tool_id": TOOL_ID,
+        "tool_version": TOOL_VERSION,
+        "can_govern_truth": False,
+    }

--- a/src/tests/test_quantity_formula_tool_contract.py
+++ b/src/tests/test_quantity_formula_tool_contract.py
@@ -1,0 +1,127 @@
+﻿from __future__ import annotations
+
+import pytest
+
+from src.application.tools.quantity_formula_tool import (
+    TOOL_ID,
+    QuantityFormulaToolError,
+    evaluate_formula,
+    quantity_formula_tool_definition,
+)
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolScope,
+    ToolSideEffect,
+)
+
+
+def test_quantity_formula_tool_definition_validates_against_registry_contract():
+    definition = quantity_formula_tool_definition()
+
+    assert definition.tool_id == TOOL_ID
+    assert definition.authority_level == ToolAuthorityLevel.DETERMINISTIC
+    assert definition.scope == ToolScope.SESSION
+    assert definition.side_effects == (ToolSideEffect.NONE,)
+    assert definition.can_govern_truth is False
+    assert definition.enabled_by_default is True
+    assert definition.requires_project is False
+    assert definition.requires_snapshot is False
+
+    definition.validate()
+
+
+@pytest.mark.parametrize(
+    ("formula_id", "inputs", "expected", "result_unit"),
+    [
+        ("rectangle_area", {"length": 5, "width": 4}, "20", "derived_area"),
+        ("room_volume", {"length": 5, "width": 4, "height": 3}, "60", "derived_volume"),
+        ("concrete_volume", {"length": 10, "width": 2, "thickness": "0.15"}, "3", "derived_volume"),
+        ("percentage_ratio", {"part": 25, "whole": 200}, "12.5", "percent"),
+        ("progress_ratio", {"completed": 30, "total": 40}, "75", "percent"),
+        ("density_mass", {"density": 2400, "volume": 2}, "4800", "derived_mass"),
+        ("linear_weight", {"unit_weight": 12, "length": 3}, "36", "derived_weight"),
+        ("circle_area", {"radius": 2}, "12.56637061435917295385057353", "derived_area"),
+    ],
+)
+def test_supported_formulas_are_deterministic(formula_id, inputs, expected, result_unit):
+    first = evaluate_formula(formula_id, inputs)
+    second = evaluate_formula(formula_id, inputs)
+
+    assert first == second
+    assert first["operation"] == "quantity_formula"
+    assert first["formula_id"] == formula_id
+    assert first["computed_result"] == expected
+    assert first["result_unit"] == result_unit
+    assert first["tool_id"] == TOOL_ID
+    assert first["tool_version"] == "1.0"
+    assert first["warnings"] == []
+    assert first["can_govern_truth"] is False
+    assert "rounding_policy" in first
+    assert "formula_or_operation" in first
+    assert isinstance(first["normalized_inputs"], dict)
+
+
+def test_formula_id_is_case_and_whitespace_normalized():
+    result = evaluate_formula(" RECTANGLE_AREA ", {"length": "2.50", "width": "4"})
+
+    assert result["formula_id"] == "rectangle_area"
+    assert result["normalized_inputs"] == {"length": "2.5", "width": "4"}
+    assert result["computed_result"] == "10"
+
+
+def test_unsupported_formula_is_controlled():
+    with pytest.raises(QuantityFormulaToolError, match="Unsupported formula"):
+        evaluate_formula("triangle_area", {"base": 2, "height": 3})
+
+
+def test_missing_required_input_is_controlled():
+    with pytest.raises(QuantityFormulaToolError, match="Missing required input"):
+        evaluate_formula("rectangle_area", {"length": 2})
+
+
+def test_extra_input_is_rejected():
+    with pytest.raises(QuantityFormulaToolError, match="Unsupported extra input"):
+        evaluate_formula("rectangle_area", {"length": 2, "width": 3, "height": 4})
+
+
+@pytest.mark.parametrize("bad_input", ["abc", "", True, object()])
+def test_non_numeric_inputs_are_rejected(bad_input):
+    with pytest.raises(QuantityFormulaToolError):
+        evaluate_formula("rectangle_area", {"length": 2, "width": bad_input})
+
+
+def test_inputs_must_be_mapping():
+    with pytest.raises(QuantityFormulaToolError, match="inputs must be a mapping"):
+        evaluate_formula("rectangle_area", None)
+
+
+def test_division_by_zero_in_percentage_ratio_is_controlled():
+    with pytest.raises(QuantityFormulaToolError, match="Division by zero"):
+        evaluate_formula("percentage_ratio", {"part": 1, "whole": 0})
+
+
+def test_division_by_zero_in_progress_ratio_is_controlled():
+    with pytest.raises(QuantityFormulaToolError, match="Division by zero"):
+        evaluate_formula("progress_ratio", {"completed": 1, "total": 0})
+
+
+def test_negative_physical_dimension_is_rejected():
+    with pytest.raises(QuantityFormulaToolError, match="Negative physical"):
+        evaluate_formula("room_volume", {"length": 2, "width": -3, "height": 4})
+
+
+def test_negative_ratio_input_is_rejected():
+    with pytest.raises(QuantityFormulaToolError, match="Negative ratio"):
+        evaluate_formula("progress_ratio", {"completed": -1, "total": 10})
+
+
+def test_quantity_formula_has_no_llm_provider_internet_file_db_or_runtime_dependency():
+    definition = quantity_formula_tool_definition()
+
+    assert definition.side_effects == (ToolSideEffect.NONE,)
+    assert definition.requires_consent is False
+    assert definition.can_govern_truth is False
+
+    result = evaluate_formula("rectangle_area", {"length": 3, "width": 5})
+    assert result["computed_result"] == "15"
+    assert result["can_govern_truth"] is False


### PR DESCRIPTION
## Summary

Adds the third deterministic local tool under the Tool Registry contract: a quantity/formula tool contract that evaluates a narrow set of explicit AECO-safe formulas and returns governed results.

This reinforces the owner rule: the application calculates, converts, and evaluates formulas locally; the LLM does not calculate, convert, or evaluate formulas.

## Scope

Added:

- `src/application/tools/quantity_formula_tool.py`
- `src/tests/test_quantity_formula_tool_contract.py`

## What this provides

- Source-defined quantity/formula tool definition using the existing Tool Registry contract
- Deterministic Decimal-based formula evaluation
- Supported formula IDs:
  - `rectangle_area`
  - `room_volume`
  - `concrete_volume`
  - `percentage_ratio`
  - `progress_ratio`
  - `density_mass`
  - `linear_weight`
  - `circle_area`
- Strict input validation
- Controlled errors for unsupported formulas, missing inputs, extra inputs, non-numeric inputs, invalid mapping inputs, division by zero, negative physical dimensions, and negative ratio inputs
- Governed result envelope with operation, formula ID, formula expression, normalized inputs, computed result, result unit, rounding policy, tool ID/version, warnings, and `can_govern_truth=false`
- Tests proving deterministic behavior and non-mutating/no-runtime/no-provider posture

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\calculator_tool.py src\application\tools\unit_conversion_tool.py src\application\tools\quantity_formula_tool.py src\tests\test_quantity_formula_tool_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_calculator_tool_contract.py src\tests\test_unit_conversion_tool_contract.py src\tests\test_quantity_formula_tool_contract.py
84 passed in 0.14s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No internet use
- No file writes
- No DB writes
- No source-of-truth mutation
- No candidate fact certification
- No quantity takeoff engine
- No symbolic math parser
- No arbitrary formula evaluation from user-provided strings
- No dimensional algebra beyond explicit formula contracts
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: controlled; deterministic explicit formula tool only
- Product risk: reduced by deterministic local formula doctrine

Related: issue #54.