### PR TITLE
Add tool invocation request response contract

### DIFF
--- a/src/application/tools/tool_invocation_contract.py
+++ b/src/application/tools/tool_invocation_contract.py
@@ -1,0 +1,151 @@
+﻿"""Source-level tool invocation request/response contracts.
+
+This module defines validation and serialization boundaries only.
+It does not execute tools, route requests, call an LLM, persist audits,
+touch storage, use internet, or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class ToolInvocationContractError(ValueError):
+    """Raised when a tool invocation request/response contract is invalid."""
+
+
+class ToolInvocationStatus(str, Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+
+
+def _validate_non_empty_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ToolInvocationContractError(f"{field_name} must be a non-empty string.")
+    return value.strip()
+
+
+def _validate_optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ToolInvocationContractError(f"{field_name} must be None or a non-empty string.")
+    return value.strip()
+
+
+def _validate_plain_mapping(value: Any, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ToolInvocationContractError(f"{field_name} must be a mapping.")
+
+    out: dict[str, Any] = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ToolInvocationContractError(f"{field_name} keys must be non-empty strings.")
+        out[key.strip()] = item
+    return out
+
+
+@dataclass(frozen=True)
+class ToolInvocationRequest:
+    """Validated request shape for future application-owned tool invocation."""
+
+    request_id: str
+    tool_id: str
+    arguments: Mapping[str, Any] = field(default_factory=dict)
+    correlation_id: str | None = None
+    requested_by: str = "system"
+    consent_granted: bool = False
+
+    def validate(self) -> None:
+        _validate_non_empty_string(self.request_id, "request_id")
+        _validate_non_empty_string(self.tool_id, "tool_id")
+        _validate_plain_mapping(self.arguments, "arguments")
+        _validate_optional_string(self.correlation_id, "correlation_id")
+        _validate_non_empty_string(self.requested_by, "requested_by")
+        if not isinstance(self.consent_granted, bool):
+            raise ToolInvocationContractError("consent_granted must be a boolean.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "request_id": _validate_non_empty_string(self.request_id, "request_id"),
+            "tool_id": _validate_non_empty_string(self.tool_id, "tool_id"),
+            "arguments": _validate_plain_mapping(self.arguments, "arguments"),
+            "correlation_id": _validate_optional_string(self.correlation_id, "correlation_id"),
+            "requested_by": _validate_non_empty_string(self.requested_by, "requested_by"),
+            "consent_granted": self.consent_granted,
+        }
+
+
+@dataclass(frozen=True)
+class ToolInvocationResponse:
+    """Validated response shape for future application-owned tool invocation."""
+
+    request_id: str
+    tool_id: str
+    status: ToolInvocationStatus
+    result: Mapping[str, Any] | None = None
+    error: Mapping[str, Any] | None = None
+    correlation_id: str | None = None
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        _validate_non_empty_string(self.request_id, "request_id")
+        _validate_non_empty_string(self.tool_id, "tool_id")
+        _normalize_status(self.status)
+        _validate_optional_string(self.correlation_id, "correlation_id")
+
+        if not isinstance(self.can_govern_truth, bool):
+            raise ToolInvocationContractError("can_govern_truth must be a boolean.")
+        if self.can_govern_truth is not False:
+            raise ToolInvocationContractError("Tool invocation responses cannot govern truth.")
+
+        status = _normalize_status(self.status)
+        if status == ToolInvocationStatus.SUCCESS:
+            if self.result is None:
+                raise ToolInvocationContractError("success response requires result.")
+            if self.error is not None:
+                raise ToolInvocationContractError("success response cannot include error.")
+            _validate_plain_mapping(self.result, "result")
+        elif status == ToolInvocationStatus.ERROR:
+            if self.error is None:
+                raise ToolInvocationContractError("error response requires error.")
+            if self.result is not None:
+                raise ToolInvocationContractError("error response cannot include result.")
+            _validate_plain_mapping(self.error, "error")
+        else:
+            raise ToolInvocationContractError(f"Unsupported status: {status}")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        status = _normalize_status(self.status)
+        return {
+            "request_id": _validate_non_empty_string(self.request_id, "request_id"),
+            "tool_id": _validate_non_empty_string(self.tool_id, "tool_id"),
+            "status": status.value,
+            "result": (
+                _validate_plain_mapping(self.result, "result")
+                if self.result is not None
+                else None
+            ),
+            "error": (
+                _validate_plain_mapping(self.error, "error")
+                if self.error is not None
+                else None
+            ),
+            "correlation_id": _validate_optional_string(self.correlation_id, "correlation_id"),
+            "can_govern_truth": False,
+        }
+
+
+def _normalize_status(value: Any) -> ToolInvocationStatus:
+    if isinstance(value, ToolInvocationStatus):
+        return value
+    if isinstance(value, str):
+        try:
+            return ToolInvocationStatus(value)
+        except ValueError as exc:
+            raise ToolInvocationContractError(f"Unsupported status: {value!r}") from exc
+    raise ToolInvocationContractError("status must be a ToolInvocationStatus or string value.")

--- a/src/tests/test_tool_invocation_contract.py
+++ b/src/tests/test_tool_invocation_contract.py
@@ -1,0 +1,235 @@
+﻿from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationContractError,
+    ToolInvocationRequest,
+    ToolInvocationResponse,
+    ToolInvocationStatus,
+)
+
+
+def test_valid_request_validates_and_serializes():
+    request = ToolInvocationRequest(
+        request_id="req-001",
+        tool_id="calculator.local",
+        arguments={"operation": "add", "inputs": [1, 2]},
+        correlation_id="chat-001",
+        requested_by="test",
+    )
+
+    request.validate()
+
+    assert request.to_dict() == {
+        "request_id": "req-001",
+        "tool_id": "calculator.local",
+        "arguments": {"operation": "add", "inputs": [1, 2]},
+        "correlation_id": "chat-001",
+        "requested_by": "test",
+        "consent_granted": False,
+    }
+
+
+def test_request_defaults_are_safe():
+    request = ToolInvocationRequest(
+        request_id="req-001",
+        tool_id="calculator.local",
+    )
+
+    assert request.to_dict()["arguments"] == {}
+    assert request.to_dict()["correlation_id"] is None
+    assert request.to_dict()["requested_by"] == "system"
+    assert request.to_dict()["consent_granted"] is False
+
+
+@pytest.mark.parametrize("bad_value", ["", "   ", None])
+def test_invalid_request_id_is_rejected(bad_value):
+    with pytest.raises(ToolInvocationContractError, match="request_id"):
+        ToolInvocationRequest(request_id=bad_value, tool_id="calculator.local").validate()
+
+
+@pytest.mark.parametrize("bad_value", ["", "   ", None])
+def test_invalid_tool_id_is_rejected(bad_value):
+    with pytest.raises(ToolInvocationContractError, match="tool_id"):
+        ToolInvocationRequest(request_id="req-001", tool_id=bad_value).validate()
+
+
+def test_non_mapping_arguments_are_rejected():
+    with pytest.raises(ToolInvocationContractError, match="arguments"):
+        ToolInvocationRequest(
+            request_id="req-001",
+            tool_id="calculator.local",
+            arguments=["not", "mapping"],
+        ).validate()
+
+
+def test_non_string_argument_keys_are_rejected():
+    with pytest.raises(ToolInvocationContractError, match="arguments keys"):
+        ToolInvocationRequest(
+            request_id="req-001",
+            tool_id="calculator.local",
+            arguments={1: "bad"},
+        ).validate()
+
+
+def test_consent_granted_must_be_boolean():
+    with pytest.raises(ToolInvocationContractError, match="consent_granted"):
+        ToolInvocationRequest(
+            request_id="req-001",
+            tool_id="calculator.local",
+            consent_granted="yes",
+        ).validate()
+
+
+def test_valid_success_response_validates_and_serializes():
+    response = ToolInvocationResponse(
+        request_id="req-001",
+        tool_id="calculator.local",
+        status=ToolInvocationStatus.SUCCESS,
+        result={
+            "operation": "calculate",
+            "tool_id": "calculator.local",
+            "tool_version": "1.0",
+            "rounding_policy": "none",
+            "warnings": [],
+            "formula_or_operation": "1 + 2",
+            "can_govern_truth": False,
+            "computed_result": "3",
+        },
+        correlation_id="chat-001",
+    )
+
+    response.validate()
+
+    out = response.to_dict()
+    assert out["status"] == "success"
+    assert out["result"]["computed_result"] == "3"
+    assert out["error"] is None
+    assert out["can_govern_truth"] is False
+
+
+def test_valid_error_response_validates_and_serializes():
+    response = ToolInvocationResponse(
+        request_id="req-001",
+        tool_id="calculator.local",
+        status=ToolInvocationStatus.ERROR,
+        error={
+            "error_type": "validation_error",
+            "message": "Invalid arguments",
+        },
+    )
+
+    response.validate()
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["result"] is None
+    assert out["error"]["error_type"] == "validation_error"
+    assert out["can_govern_truth"] is False
+
+
+def test_success_response_requires_result():
+    with pytest.raises(ToolInvocationContractError, match="requires result"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status=ToolInvocationStatus.SUCCESS,
+        ).validate()
+
+
+def test_success_response_cannot_include_error():
+    with pytest.raises(ToolInvocationContractError, match="cannot include error"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status=ToolInvocationStatus.SUCCESS,
+            result={"ok": True},
+            error={"message": "bad"},
+        ).validate()
+
+
+def test_error_response_requires_error():
+    with pytest.raises(ToolInvocationContractError, match="requires error"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status=ToolInvocationStatus.ERROR,
+        ).validate()
+
+
+def test_error_response_cannot_include_result():
+    with pytest.raises(ToolInvocationContractError, match="cannot include result"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status=ToolInvocationStatus.ERROR,
+            result={"ok": True},
+            error={"message": "bad"},
+        ).validate()
+
+
+def test_unknown_status_is_rejected():
+    with pytest.raises(ToolInvocationContractError, match="Unsupported status"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status="pending",
+            result={"ok": True},
+        ).validate()
+
+
+def test_response_cannot_govern_truth():
+    with pytest.raises(ToolInvocationContractError, match="cannot govern truth"):
+        ToolInvocationResponse(
+            request_id="req-001",
+            tool_id="calculator.local",
+            status=ToolInvocationStatus.SUCCESS,
+            result={"ok": True},
+            can_govern_truth=True,
+        ).validate()
+
+
+def test_request_and_response_are_json_serializable():
+    request = ToolInvocationRequest(
+        request_id="req-001",
+        tool_id="calculator.local",
+        arguments={"operation": "add"},
+    )
+    response = ToolInvocationResponse(
+        request_id="req-001",
+        tool_id="calculator.local",
+        status="success",
+        result={"operation": "calculate", "can_govern_truth": False},
+    )
+
+    assert json.loads(json.dumps(request.to_dict())) == request.to_dict()
+    assert json.loads(json.dumps(response.to_dict())) == response.to_dict()
+
+
+def test_contract_does_not_execute_tools(monkeypatch):
+    executed = {"called": False}
+
+    def fake_execute(*args, **kwargs):
+        executed["called"] = True
+        return {"bad": True}
+
+    monkeypatch.setitem(globals(), "fake_execute", fake_execute)
+
+    request = ToolInvocationRequest(
+        request_id="req-001",
+        tool_id="calculator.local",
+        arguments={"operation": "multiply", "inputs": [6, 7]},
+    )
+    response = ToolInvocationResponse(
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        status=ToolInvocationStatus.ERROR,
+        error={"error_type": "not_executed", "message": "Contract only"},
+    )
+
+    assert request.to_dict()["arguments"]["operation"] == "multiply"
+    assert response.to_dict()["error"]["error_type"] == "not_executed"
+    assert executed["called"] is False


### PR DESCRIPTION
## Summary

Adds a bounded source-level request/response contract for future application-owned tool invocation.

This does not execute tools. It only defines validated request and response shapes that a future router/chat layer may use after explicit approval.

## Scope

Added:

- `src/application/tools/tool_invocation_contract.py`
- `src/tests/test_tool_invocation_contract.py`

## What this provides

- `ToolInvocationRequest` dataclass
- `ToolInvocationResponse` dataclass
- `ToolInvocationStatus` enum
- Contract error type
- Request validation for:
  - request ID
  - tool ID
  - plain argument mapping
  - optional correlation ID
  - requested-by source
  - explicit consent flag
- Response validation for:
  - success/error status
  - success result envelope rules
  - error envelope rules
  - truth-governance lockout
- `to_dict()` serialization helpers
- Tests proving the contract does not execute tools

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\tool_invocation_contract.py src\tests\test_tool_invocation_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py
53 passed in 0.12s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No tool execution loop
- No LLM tool-call parser
- No MCP integration
- No internet use
- No file writes
- No DB writes
- No audit persistence implementation
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; contract-only boundary
- Product risk: reduced by locking invocation shape before routing

Related: issue #58.