### PR TITLE
Add non-executing tool resolver contract

### DIFF
--- a/src/application/tools/tool_resolver.py
+++ b/src/application/tools/tool_resolver.py
@@ -1,0 +1,129 @@
+﻿"""Non-executing resolver for application-owned tool definitions.
+
+This module resolves tool IDs to ToolDefinition metadata only.
+It does not execute tools, route requests, call an LLM, persist audits,
+touch storage, use internet, or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Mapping
+
+from src.application.tools.calculator_tool import calculator_tool_definition
+from src.application.tools.quantity_formula_tool import quantity_formula_tool_definition
+from src.application.tools.tool_registry import ToolDefinition
+from src.application.tools.unit_conversion_tool import unit_conversion_tool_definition
+
+
+class ToolResolverContractError(ValueError):
+    """Raised when resolver input is invalid."""
+
+
+class ToolResolutionStatus(str, Enum):
+    RESOLVED = "resolved"
+    NOT_FOUND = "not_found"
+
+
+DefinitionFactory = Callable[[], ToolDefinition]
+
+
+DEFAULT_TOOL_DEFINITION_FACTORIES: Mapping[str, DefinitionFactory] = {
+    "calculator.local": calculator_tool_definition,
+    "unit_conversion.local": unit_conversion_tool_definition,
+    "quantity_formula.local": quantity_formula_tool_definition,
+}
+
+
+@dataclass(frozen=True)
+class ToolResolution:
+    """Plain non-executing resolution envelope."""
+
+    tool_id: str
+    status: ToolResolutionStatus
+    is_resolvable: bool
+    display_name: str | None = None
+    authority_level: str | None = None
+    scope: str | None = None
+    side_effects: tuple[str, ...] = ()
+    requires_consent: bool | None = None
+    can_govern_truth: bool | None = None
+    enabled_by_default: bool | None = None
+    requires_project: bool | None = None
+    requires_snapshot: bool | None = None
+    warnings: tuple[str, ...] = ()
+    error: Mapping[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "status": self.status.value,
+            "is_resolvable": self.is_resolvable,
+            "display_name": self.display_name,
+            "authority_level": self.authority_level,
+            "scope": self.scope,
+            "side_effects": list(self.side_effects),
+            "requires_consent": self.requires_consent,
+            "can_govern_truth": self.can_govern_truth,
+            "enabled_by_default": self.enabled_by_default,
+            "requires_project": self.requires_project,
+            "requires_snapshot": self.requires_snapshot,
+            "warnings": list(self.warnings),
+            "error": dict(self.error) if self.error is not None else None,
+        }
+
+
+def _normalize_tool_id(tool_id: Any) -> str:
+    if not isinstance(tool_id, str) or not tool_id.strip():
+        raise ToolResolverContractError("tool_id must be a non-empty string.")
+    return tool_id.strip()
+
+
+def resolve_tool(
+    tool_id: Any,
+    definition_factories: Mapping[str, DefinitionFactory] | None = None,
+) -> ToolResolution:
+    """Resolve a tool ID to metadata without executing the tool."""
+
+    normalized_tool_id = _normalize_tool_id(tool_id)
+    catalog = dict(definition_factories or DEFAULT_TOOL_DEFINITION_FACTORIES)
+
+    factory = catalog.get(normalized_tool_id)
+    if factory is None:
+        return ToolResolution(
+            tool_id=normalized_tool_id,
+            status=ToolResolutionStatus.NOT_FOUND,
+            is_resolvable=False,
+            warnings=(),
+            error={
+                "error_type": "tool_not_found",
+                "message": f"Tool is not registered: {normalized_tool_id}",
+            },
+        )
+
+    definition = factory()
+    definition.validate()
+
+    return ToolResolution(
+        tool_id=definition.tool_id,
+        status=ToolResolutionStatus.RESOLVED,
+        is_resolvable=True,
+        display_name=definition.display_name,
+        authority_level=definition.authority_level.value,
+        scope=definition.scope.value,
+        side_effects=tuple(effect.value for effect in definition.side_effects),
+        requires_consent=definition.requires_consent,
+        can_govern_truth=definition.can_govern_truth,
+        enabled_by_default=definition.enabled_by_default,
+        requires_project=definition.requires_project,
+        requires_snapshot=definition.requires_snapshot,
+        warnings=(),
+        error=None,
+    )
+
+
+def default_resolvable_tool_ids() -> tuple[str, ...]:
+    """Return the default resolver catalog tool IDs without mutating catalog state."""
+
+    return tuple(sorted(DEFAULT_TOOL_DEFINITION_FACTORIES))

--- a/src/tests/test_tool_resolver_contract.py
+++ b/src/tests/test_tool_resolver_contract.py
@@ -1,0 +1,152 @@
+﻿from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import (
+    TOOL_ID as CALCULATOR_TOOL_ID,
+    calculate,
+)
+from src.application.tools.quantity_formula_tool import (
+    TOOL_ID as QUANTITY_FORMULA_TOOL_ID,
+    evaluate_formula,
+)
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolScope,
+    ToolSideEffect,
+)
+from src.application.tools.tool_resolver import (
+    ToolResolutionStatus,
+    ToolResolverContractError,
+    default_resolvable_tool_ids,
+    resolve_tool,
+)
+from src.application.tools.unit_conversion_tool import (
+    TOOL_ID as UNIT_CONVERSION_TOOL_ID,
+    convert_unit,
+)
+
+
+EXPECTED_TOOL_IDS = (
+    CALCULATOR_TOOL_ID,
+    UNIT_CONVERSION_TOOL_ID,
+    QUANTITY_FORMULA_TOOL_ID,
+)
+
+
+@pytest.mark.parametrize("tool_id", EXPECTED_TOOL_IDS)
+def test_known_deterministic_tool_ids_resolve_successfully(tool_id):
+    resolution = resolve_tool(tool_id)
+    out = resolution.to_dict()
+
+    assert out["tool_id"] == tool_id
+    assert out["status"] == ToolResolutionStatus.RESOLVED.value
+    assert out["is_resolvable"] is True
+    assert out["display_name"]
+    assert out["authority_level"] == ToolAuthorityLevel.DETERMINISTIC.value
+    assert out["scope"] == ToolScope.SESSION.value
+    assert out["side_effects"] == [ToolSideEffect.NONE.value]
+    assert out["requires_consent"] is False
+    assert out["can_govern_truth"] is False
+    assert out["enabled_by_default"] is True
+    assert out["requires_project"] is False
+    assert out["requires_snapshot"] is False
+    assert out["warnings"] == []
+    assert out["error"] is None
+
+
+def test_tool_id_whitespace_is_normalized_only():
+    resolution = resolve_tool("  calculator.local  ")
+
+    assert resolution.to_dict()["tool_id"] == "calculator.local"
+    assert resolution.to_dict()["status"] == "resolved"
+
+
+def test_unknown_tool_id_returns_controlled_not_found():
+    resolution = resolve_tool("unknown.local")
+    out = resolution.to_dict()
+
+    assert out["tool_id"] == "unknown.local"
+    assert out["status"] == ToolResolutionStatus.NOT_FOUND.value
+    assert out["is_resolvable"] is False
+    assert out["display_name"] is None
+    assert out["authority_level"] is None
+    assert out["scope"] is None
+    assert out["side_effects"] == []
+    assert out["can_govern_truth"] is None
+    assert out["error"]["error_type"] == "tool_not_found"
+
+
+@pytest.mark.parametrize("bad_tool_id", ["", "   ", None, 123])
+def test_empty_or_non_string_tool_id_is_rejected(bad_tool_id):
+    with pytest.raises(ToolResolverContractError, match="tool_id"):
+        resolve_tool(bad_tool_id)
+
+
+def test_default_resolvable_tool_ids_are_stable_sorted_tuple():
+    assert default_resolvable_tool_ids() == tuple(sorted(EXPECTED_TOOL_IDS))
+
+
+def test_resolution_envelope_is_json_serializable():
+    resolution = resolve_tool("calculator.local").to_dict()
+
+    assert json.loads(json.dumps(resolution, sort_keys=True)) == resolution
+
+
+def test_unknown_resolution_envelope_is_json_serializable():
+    resolution = resolve_tool("missing.local").to_dict()
+
+    assert json.loads(json.dumps(resolution, sort_keys=True)) == resolution
+
+
+def test_resolver_does_not_execute_tool_implementations(monkeypatch):
+    called = {
+        "calculate": False,
+        "convert_unit": False,
+        "evaluate_formula": False,
+    }
+
+    def blocked_calculate(*args, **kwargs):
+        called["calculate"] = True
+        raise AssertionError("calculate must not be called by resolver")
+
+    def blocked_convert_unit(*args, **kwargs):
+        called["convert_unit"] = True
+        raise AssertionError("convert_unit must not be called by resolver")
+
+    def blocked_evaluate_formula(*args, **kwargs):
+        called["evaluate_formula"] = True
+        raise AssertionError("evaluate_formula must not be called by resolver")
+
+    monkeypatch.setattr(
+        "src.application.tools.calculator_tool.calculate",
+        blocked_calculate,
+    )
+    monkeypatch.setattr(
+        "src.application.tools.unit_conversion_tool.convert_unit",
+        blocked_convert_unit,
+    )
+    monkeypatch.setattr(
+        "src.application.tools.quantity_formula_tool.evaluate_formula",
+        blocked_evaluate_formula,
+    )
+
+    for tool_id in EXPECTED_TOOL_IDS:
+        assert resolve_tool(tool_id).is_resolvable is True
+
+    assert called == {
+        "calculate": False,
+        "convert_unit": False,
+        "evaluate_formula": False,
+    }
+
+
+def test_imported_tool_functions_remain_callable_outside_resolver():
+    # Guard against a false-positive monkeypatch assumption in the non-execution test.
+    assert calculate("add", [1, 2])["computed_result"] == "3"
+    assert convert_unit(1, "m", "cm", "length")["converted_value"] == "100"
+    assert evaluate_formula("rectangle_area", {"length": 2, "width": 3})[
+        "computed_result"
+    ] == "6"


### PR DESCRIPTION
## Summary

Adds a bounded non-executing resolver contract for application-owned tools.

This does not execute tools. It resolves a requested `tool_id` to registered `ToolDefinition` metadata and returns a safe resolution envelope that future router/chat layers may use after explicit approval.

## Scope

Added:

- `src/application/tools/tool_resolver.py`
- `src/tests/test_tool_resolver_contract.py`

## What this provides

- `ToolResolution` dataclass
- `ToolResolutionStatus` enum
- `ToolResolverContractError`
- Default read-only resolver catalog for:
  - `calculator.local`
  - `unit_conversion.local`
  - `quantity_formula.local`
- Resolver behavior for:
  - known tool IDs
  - whitespace-only normalization
  - unknown tool IDs
  - empty/non-string tool IDs
  - safe metadata exposure
- Resolution envelope fields for authority level, scope, side effects, consent requirement, project/snapshot requirement, enabled posture, truth-governance posture, warnings, and error envelope
- Tests proving resolver does not execute calculator, unit conversion, or quantity/formula implementations

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\calculator_tool.py src\application\tools\unit_conversion_tool.py src\application\tools\quantity_formula_tool.py src\application\tools\tool_resolver.py src\tests\test_tool_resolver_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py
67 passed in 0.14s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No tool execution loop
- No LLM tool-call parser
- No MCP integration
- No internet use
- No file writes
- No DB writes
- No audit persistence implementation
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; non-executing resolver only
- Product risk: reduced by locking tool resolution behavior before execution routing

Related: issue #60.