### PR TITLE
Add non-executing tool eligibility gate

### DIFF
--- a/src/application/tools/tool_eligibility_gate.py
+++ b/src/application/tools/tool_eligibility_gate.py
@@ -1,0 +1,159 @@
+﻿"""Non-executing eligibility gate for application-owned tools.
+
+This module decides whether a resolved tool is eligible for future invocation.
+It does not execute tools, route requests, call an LLM, persist audits,
+touch storage, use internet, or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolScope,
+    ToolSideEffect,
+)
+from src.application.tools.tool_resolver import (
+    ToolResolution,
+    ToolResolverContractError,
+    resolve_tool,
+)
+
+
+class ToolEligibilityDecision(str, Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+@dataclass(frozen=True)
+class ToolEligibility:
+    """Plain non-executing eligibility envelope."""
+
+    tool_id: str
+    is_eligible: bool
+    decision: ToolEligibilityDecision
+    reasons: tuple[str, ...]
+    warnings: tuple[str, ...]
+    resolution_status: str
+    can_govern_truth: bool | None
+    requires_consent: bool | None
+    consent_granted: bool
+    requires_project: bool | None
+    project_available: bool
+    requires_snapshot: bool | None
+    snapshot_available: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "is_eligible": self.is_eligible,
+            "decision": self.decision.value,
+            "reasons": list(self.reasons),
+            "warnings": list(self.warnings),
+            "resolution_status": self.resolution_status,
+            "can_govern_truth": self.can_govern_truth,
+            "requires_consent": self.requires_consent,
+            "consent_granted": self.consent_granted,
+            "requires_project": self.requires_project,
+            "project_available": self.project_available,
+            "requires_snapshot": self.requires_snapshot,
+            "snapshot_available": self.snapshot_available,
+        }
+
+
+def check_tool_eligibility(
+    tool_id: Any,
+    *,
+    consent_granted: bool = False,
+    project_available: bool = False,
+    snapshot_available: bool = False,
+    definition_factories: Mapping[str, Any] | None = None,
+) -> ToolEligibility:
+    """Return a deterministic allow/deny envelope without executing the tool."""
+
+    if not isinstance(consent_granted, bool):
+        raise ToolResolverContractError("consent_granted must be a boolean.")
+    if not isinstance(project_available, bool):
+        raise ToolResolverContractError("project_available must be a boolean.")
+    if not isinstance(snapshot_available, bool):
+        raise ToolResolverContractError("snapshot_available must be a boolean.")
+
+    try:
+        resolution = resolve_tool(
+            tool_id,
+            definition_factories=definition_factories,
+        )
+    except ToolResolverContractError:
+        raise
+
+    return _eligibility_from_resolution(
+        resolution,
+        consent_granted=consent_granted,
+        project_available=project_available,
+        snapshot_available=snapshot_available,
+    )
+
+
+def _eligibility_from_resolution(
+    resolution: ToolResolution,
+    *,
+    consent_granted: bool,
+    project_available: bool,
+    snapshot_available: bool,
+) -> ToolEligibility:
+    reasons: list[str] = []
+    warnings = tuple(resolution.warnings)
+
+    if not resolution.is_resolvable:
+        reasons.append("tool_not_resolved")
+
+    if resolution.enabled_by_default is False:
+        reasons.append("tool_disabled")
+
+    if resolution.authority_level != ToolAuthorityLevel.DETERMINISTIC.value:
+        reasons.append("unsupported_authority_level")
+
+    if resolution.scope != ToolScope.SESSION.value:
+        reasons.append("unsupported_scope")
+
+    if tuple(resolution.side_effects) != (ToolSideEffect.NONE.value,):
+        reasons.append("side_effects_not_allowed")
+
+    if resolution.can_govern_truth is not False:
+        reasons.append("truth_governance_not_allowed")
+
+    if resolution.requires_consent is True and consent_granted is False:
+        reasons.append("consent_required")
+
+    if resolution.requires_project is True and project_available is False:
+        reasons.append("project_required")
+
+    if resolution.requires_snapshot is True and snapshot_available is False:
+        reasons.append("snapshot_required")
+
+    is_eligible = not reasons
+    if is_eligible:
+        reasons.append("eligible")
+
+    return ToolEligibility(
+        tool_id=resolution.tool_id,
+        is_eligible=is_eligible,
+        decision=(
+            ToolEligibilityDecision.ALLOW
+            if is_eligible
+            else ToolEligibilityDecision.DENY
+        ),
+        reasons=tuple(reasons),
+        warnings=warnings,
+        resolution_status=resolution.status.value,
+        can_govern_truth=resolution.can_govern_truth,
+        requires_consent=resolution.requires_consent,
+        consent_granted=consent_granted,
+        requires_project=resolution.requires_project,
+        project_available=project_available,
+        requires_snapshot=resolution.requires_snapshot,
+        snapshot_available=snapshot_available,
+    )

--- a/src/tests/test_tool_eligibility_gate_contract.py
+++ b/src/tests/test_tool_eligibility_gate_contract.py
@@ -1,0 +1,303 @@
+﻿from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import (
+    TOOL_ID as CALCULATOR_TOOL_ID,
+    calculate,
+    calculator_tool_definition,
+)
+from src.application.tools.quantity_formula_tool import (
+    TOOL_ID as QUANTITY_FORMULA_TOOL_ID,
+    evaluate_formula,
+)
+from src.application.tools.tool_eligibility_gate import (
+    ToolEligibilityDecision,
+    check_tool_eligibility,
+)
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+)
+from src.application.tools.tool_resolver import ToolResolverContractError
+from src.application.tools.unit_conversion_tool import (
+    TOOL_ID as UNIT_CONVERSION_TOOL_ID,
+    convert_unit,
+)
+
+
+EXPECTED_TOOL_IDS = (
+    CALCULATOR_TOOL_ID,
+    UNIT_CONVERSION_TOOL_ID,
+    QUANTITY_FORMULA_TOOL_ID,
+)
+
+
+@pytest.mark.parametrize("tool_id", EXPECTED_TOOL_IDS)
+def test_known_deterministic_tools_are_eligible_by_default(tool_id):
+    eligibility = check_tool_eligibility(tool_id).to_dict()
+
+    assert eligibility["tool_id"] == tool_id
+    assert eligibility["is_eligible"] is True
+    assert eligibility["decision"] == ToolEligibilityDecision.ALLOW.value
+    assert eligibility["reasons"] == ["eligible"]
+    assert eligibility["warnings"] == []
+    assert eligibility["resolution_status"] == "resolved"
+    assert eligibility["can_govern_truth"] is False
+    assert eligibility["requires_consent"] is False
+    assert eligibility["consent_granted"] is False
+    assert eligibility["requires_project"] is False
+    assert eligibility["project_available"] is False
+    assert eligibility["requires_snapshot"] is False
+    assert eligibility["snapshot_available"] is False
+
+
+def test_unknown_tool_id_is_denied_cleanly():
+    eligibility = check_tool_eligibility("unknown.local").to_dict()
+
+    assert eligibility["tool_id"] == "unknown.local"
+    assert eligibility["is_eligible"] is False
+    assert eligibility["decision"] == "deny"
+    assert "tool_not_resolved" in eligibility["reasons"]
+    assert "unsupported_authority_level" in eligibility["reasons"]
+    assert "unsupported_scope" in eligibility["reasons"]
+    assert "side_effects_not_allowed" in eligibility["reasons"]
+    assert "truth_governance_not_allowed" in eligibility["reasons"]
+    assert eligibility["resolution_status"] == "not_found"
+
+
+@pytest.mark.parametrize("bad_tool_id", ["", "   ", None, 123])
+def test_empty_or_non_string_tool_id_is_controlled(bad_tool_id):
+    with pytest.raises(ToolResolverContractError, match="tool_id"):
+        check_tool_eligibility(bad_tool_id)
+
+
+@pytest.mark.parametrize(
+    ("flag_name", "kwargs"),
+    [
+        ("consent_granted", {"consent_granted": "yes"}),
+        ("project_available", {"project_available": "yes"}),
+        ("snapshot_available", {"snapshot_available": "yes"}),
+    ],
+)
+def test_context_flags_must_be_boolean(flag_name, kwargs):
+    with pytest.raises(ToolResolverContractError, match=flag_name):
+        check_tool_eligibility("calculator.local", **kwargs)
+
+
+def _definition_with(**overrides):
+    base = calculator_tool_definition()
+    values = {
+        "tool_id": "custom.local",
+        "display_name": base.display_name,
+        "description": base.description,
+        "input_schema": base.input_schema,
+        "output_schema": base.output_schema,
+        "authority_level": base.authority_level,
+        "scope": base.scope,
+        "side_effects": base.side_effects,
+        "requires_consent": base.requires_consent,
+        "can_govern_truth": base.can_govern_truth,
+        "audit_log_required": base.audit_log_required,
+        "enabled_by_default": base.enabled_by_default,
+        "requires_project": base.requires_project,
+        "requires_snapshot": base.requires_snapshot,
+        "result_provenance_required": base.result_provenance_required,
+    }
+    values.update(overrides)
+    definition = ToolDefinition(**values)
+    definition.validate()
+    return definition
+
+
+def _catalog_for(definition):
+    return {"custom.local": lambda: definition}
+
+
+def test_disabled_tool_is_denied():
+    eligibility = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(_definition_with(enabled_by_default=False)),
+    ).to_dict()
+
+    assert eligibility["is_eligible"] is False
+    assert "tool_disabled" in eligibility["reasons"]
+
+
+def test_side_effecting_tool_is_denied_with_registry_valid_definition():
+    side_effect = next(effect for effect in ToolSideEffect if effect != ToolSideEffect.NONE)
+
+    eligibility = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(
+            _definition_with(
+                side_effects=(side_effect,),
+                enabled_by_default=False,
+                requires_consent=True,
+            )
+        ),
+    ).to_dict()
+
+    assert eligibility["is_eligible"] is False
+    assert "tool_disabled" in eligibility["reasons"]
+    assert "side_effects_not_allowed" in eligibility["reasons"]
+    assert "consent_required" in eligibility["reasons"]
+
+
+def test_truth_governing_tool_is_denied_with_registry_valid_definition():
+    eligibility = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(
+            _definition_with(
+                can_govern_truth=True,
+                result_provenance_required=True,
+            )
+        ),
+    ).to_dict()
+
+    assert eligibility["is_eligible"] is False
+    assert "truth_governance_not_allowed" in eligibility["reasons"]
+
+
+def test_consent_required_tool_is_denied_without_consent_and_allowed_with_consent():
+    definition = _definition_with(requires_consent=True)
+    denied = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+    allowed = check_tool_eligibility(
+        "custom.local",
+        consent_granted=True,
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+
+    assert denied["is_eligible"] is False
+    assert "consent_required" in denied["reasons"]
+    assert allowed["is_eligible"] is True
+    assert allowed["reasons"] == ["eligible"]
+
+
+def test_project_required_tool_is_denied_without_project_context_and_allowed_with_project():
+    definition = _definition_with(requires_project=True)
+    denied = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+    allowed = check_tool_eligibility(
+        "custom.local",
+        project_available=True,
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+
+    assert denied["is_eligible"] is False
+    assert "project_required" in denied["reasons"]
+    assert allowed["is_eligible"] is True
+    assert allowed["reasons"] == ["eligible"]
+
+
+def test_snapshot_required_tool_is_denied_without_snapshot_context_and_allowed_with_snapshot():
+    definition = _definition_with(
+        requires_project=True,
+        requires_snapshot=True,
+    )
+    denied = check_tool_eligibility(
+        "custom.local",
+        project_available=True,
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+    allowed = check_tool_eligibility(
+        "custom.local",
+        project_available=True,
+        snapshot_available=True,
+        definition_factories=_catalog_for(definition),
+    ).to_dict()
+
+    assert denied["is_eligible"] is False
+    assert "snapshot_required" in denied["reasons"]
+    assert allowed["is_eligible"] is True
+    assert allowed["reasons"] == ["eligible"]
+
+
+def test_non_deterministic_authority_is_denied_with_registry_valid_definition():
+    eligibility = check_tool_eligibility(
+        "custom.local",
+        definition_factories=_catalog_for(
+            _definition_with(authority_level=ToolAuthorityLevel.EXTERNAL)
+        ),
+    ).to_dict()
+
+    assert eligibility["is_eligible"] is False
+    assert "unsupported_authority_level" in eligibility["reasons"]
+
+
+def test_non_session_scope_is_denied_with_registry_valid_definition():
+    eligibility = check_tool_eligibility(
+        "custom.local",
+        project_available=True,
+        definition_factories=_catalog_for(
+            _definition_with(scope=ToolScope.PROJECT, requires_project=True)
+        ),
+    ).to_dict()
+
+    assert eligibility["is_eligible"] is False
+    assert "unsupported_scope" in eligibility["reasons"]
+
+
+def test_eligibility_result_is_json_serializable():
+    eligibility = check_tool_eligibility("calculator.local").to_dict()
+
+    assert json.loads(json.dumps(eligibility, sort_keys=True)) == eligibility
+
+
+def test_gate_does_not_execute_tool_implementations(monkeypatch):
+    called = {
+        "calculate": False,
+        "convert_unit": False,
+        "evaluate_formula": False,
+    }
+
+    def blocked_calculate(*args, **kwargs):
+        called["calculate"] = True
+        raise AssertionError("calculate must not be called by eligibility gate")
+
+    def blocked_convert_unit(*args, **kwargs):
+        called["convert_unit"] = True
+        raise AssertionError("convert_unit must not be called by eligibility gate")
+
+    def blocked_evaluate_formula(*args, **kwargs):
+        called["evaluate_formula"] = True
+        raise AssertionError("evaluate_formula must not be called by eligibility gate")
+
+    monkeypatch.setattr(
+        "src.application.tools.calculator_tool.calculate",
+        blocked_calculate,
+    )
+    monkeypatch.setattr(
+        "src.application.tools.unit_conversion_tool.convert_unit",
+        blocked_convert_unit,
+    )
+    monkeypatch.setattr(
+        "src.application.tools.quantity_formula_tool.evaluate_formula",
+        blocked_evaluate_formula,
+    )
+
+    for tool_id in EXPECTED_TOOL_IDS:
+        assert check_tool_eligibility(tool_id).is_eligible is True
+
+    assert called == {
+        "calculate": False,
+        "convert_unit": False,
+        "evaluate_formula": False,
+    }
+
+
+def test_imported_tool_functions_remain_callable_outside_gate():
+    assert calculate("add", [1, 2])["computed_result"] == "3"
+    assert convert_unit(1, "m", "cm", "length")["converted_value"] == "100"
+    assert evaluate_formula("rectangle_area", {"length": 2, "width": 3})[
+        "computed_result"
+    ] == "6"


### PR DESCRIPTION
## Summary

Adds a bounded non-executing eligibility gate for application-owned tools.

This does not execute tools. It checks whether a resolved tool is eligible for future invocation under current policy and returns a deterministic allow/deny envelope that future router/chat layers may use after explicit approval.

## Scope

Added:

- `src/application/tools/tool_eligibility_gate.py`
- `src/tests/test_tool_eligibility_gate_contract.py`

## What this provides

- `ToolEligibility` dataclass
- `ToolEligibilityDecision` enum
- `check_tool_eligibility(...)` contract function
- Deterministic allow/deny policy for current local deterministic tools
- Eligibility checks for:
  - resolution status
  - enabled state
  - authority level
  - scope
  - side effects
  - truth-governance posture
  - consent requirement
  - project requirement
  - snapshot requirement
- Controlled handling of unknown and invalid tool IDs
- JSON-serializable eligibility envelope
- Tests proving the gate does not execute calculator, unit conversion, or quantity/formula implementations

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\tool_resolver.py src\application\tools\tool_eligibility_gate.py src\tests\test_tool_eligibility_gate_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py
89 passed in 0.17s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No tool execution loop
- No LLM tool-call parser
- No MCP integration
- No internet use
- No file writes
- No DB writes
- No audit persistence implementation
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; non-executing eligibility gate only
- Product risk: reduced by locking policy gate behavior before execution routing

Related: issue #62.