### PR TITLE
Add bounded tool execution harness

### DIFF
--- a/src/application/tools/tool_execution_harness.py
+++ b/src/application/tools/tool_execution_harness.py
@@ -1,0 +1,193 @@
+﻿"""Bounded execution harness for deterministic local tools.
+
+This module executes approved deterministic local tools only after request
+validation, resolver lookup, and eligibility checks. It does not wire chat,
+parse LLM tool calls, persist audits, touch storage, use internet, or interact
+with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Callable
+
+from src.application.tools.calculator_tool import (
+    TOOL_ID as CALCULATOR_TOOL_ID,
+    calculate,
+)
+from src.application.tools.quantity_formula_tool import (
+    TOOL_ID as QUANTITY_FORMULA_TOOL_ID,
+    evaluate_formula,
+)
+from src.application.tools.tool_eligibility_gate import check_tool_eligibility
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationContractError,
+    ToolInvocationRequest,
+    ToolInvocationResponse,
+    ToolInvocationStatus,
+)
+from src.application.tools.tool_resolver import ToolResolverContractError
+from src.application.tools.unit_conversion_tool import (
+    TOOL_ID as UNIT_CONVERSION_TOOL_ID,
+    convert_unit,
+)
+
+
+class ToolExecutionHarnessError(ValueError):
+    """Raised for internal harness contract failures."""
+
+
+ToolExecutor = Callable[[Mapping[str, Any]], Mapping[str, Any]]
+
+
+def execute_tool_invocation(
+    request: ToolInvocationRequest,
+    *,
+    executors: Mapping[str, ToolExecutor] | None = None,
+    definition_factories: Mapping[str, Any] | None = None,
+) -> ToolInvocationResponse:
+    """Execute an approved deterministic local tool invocation."""
+
+    if not isinstance(request, ToolInvocationRequest):
+        raise ToolExecutionHarnessError(
+            "request must be a ToolInvocationRequest instance."
+        )
+
+    try:
+        request.validate()
+    except ToolInvocationContractError as exc:
+        return _error_response(
+            request_id=_safe_attr(request, "request_id", ""),
+            tool_id=_safe_attr(request, "tool_id", ""),
+            correlation_id=_safe_attr(request, "correlation_id", None),
+            error_type="invalid_request",
+            message=str(exc),
+        )
+
+    try:
+        eligibility = check_tool_eligibility(
+            request.tool_id,
+            consent_granted=request.consent_granted,
+            definition_factories=definition_factories,
+        )
+    except ToolResolverContractError as exc:
+        return _error_response(
+            request_id=request.request_id,
+            tool_id=request.tool_id,
+            correlation_id=request.correlation_id,
+            error_type="tool_resolution_error",
+            message=str(exc),
+        )
+
+    if not eligibility.is_eligible:
+        return _error_response(
+            request_id=request.request_id,
+            tool_id=request.tool_id,
+            correlation_id=request.correlation_id,
+            error_type="tool_not_eligible",
+            message="Tool is not eligible for execution.",
+            details=eligibility.to_dict(),
+        )
+
+    executor_catalog = dict(executors or _default_executors())
+    executor = executor_catalog.get(request.tool_id)
+    if executor is None:
+        return _error_response(
+            request_id=request.request_id,
+            tool_id=request.tool_id,
+            correlation_id=request.correlation_id,
+            error_type="executor_not_registered",
+            message=f"No executor is registered for tool: {request.tool_id}",
+        )
+
+    try:
+        result = dict(executor(request.arguments))
+    except Exception as exc:  # noqa: BLE001 - convert tool failures to response envelope
+        return _error_response(
+            request_id=request.request_id,
+            tool_id=request.tool_id,
+            correlation_id=request.correlation_id,
+            error_type="tool_execution_error",
+            message=str(exc),
+        )
+
+    return ToolInvocationResponse(
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        status=ToolInvocationStatus.SUCCESS,
+        result=result,
+        error=None,
+        correlation_id=request.correlation_id,
+        can_govern_truth=False,
+    )
+
+
+def _default_executors() -> dict[str, ToolExecutor]:
+    return {
+        CALCULATOR_TOOL_ID: _execute_calculator,
+        UNIT_CONVERSION_TOOL_ID: _execute_unit_conversion,
+        QUANTITY_FORMULA_TOOL_ID: _execute_quantity_formula,
+    }
+
+
+def _execute_calculator(arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+    operation = _required(arguments, "operation")
+    operands = arguments.get("operands", arguments.get("inputs"))
+    if operands is None:
+        raise ToolExecutionHarnessError(
+            "calculator.local requires operands or inputs."
+        )
+    return calculate(operation, operands)
+
+
+def _execute_unit_conversion(arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+    return convert_unit(
+        _required(arguments, "value"),
+        _required(arguments, "from_unit"),
+        _required(arguments, "to_unit"),
+        _required(arguments, "dimension"),
+    )
+
+
+def _execute_quantity_formula(arguments: Mapping[str, Any]) -> Mapping[str, Any]:
+    return evaluate_formula(
+        _required(arguments, "formula_id"),
+        _required(arguments, "inputs"),
+    )
+
+
+def _required(arguments: Mapping[str, Any], key: str) -> Any:
+    if key not in arguments:
+        raise ToolExecutionHarnessError(f"Missing required argument: {key}")
+    return arguments[key]
+
+
+def _error_response(
+    *,
+    request_id: str,
+    tool_id: str,
+    correlation_id: str | None,
+    error_type: str,
+    message: str,
+    details: Mapping[str, Any] | None = None,
+) -> ToolInvocationResponse:
+    error: dict[str, Any] = {
+        "error_type": error_type,
+        "message": message,
+    }
+    if details is not None:
+        error["details"] = dict(details)
+
+    return ToolInvocationResponse(
+        request_id=request_id or "invalid-request",
+        tool_id=tool_id or "invalid-tool",
+        status=ToolInvocationStatus.ERROR,
+        result=None,
+        error=error,
+        correlation_id=correlation_id,
+        can_govern_truth=False,
+    )
+
+
+def _safe_attr(obj: object, attr: str, default: Any) -> Any:
+    return getattr(obj, attr, default)

--- a/src/tests/test_tool_execution_harness_contract.py
+++ b/src/tests/test_tool_execution_harness_contract.py
@@ -1,0 +1,233 @@
+﻿from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import (
+    TOOL_ID as CALCULATOR_TOOL_ID,
+    calculator_tool_definition,
+)
+from src.application.tools.quantity_formula_tool import TOOL_ID as QUANTITY_FORMULA_TOOL_ID
+from src.application.tools.tool_execution_harness import (
+    ToolExecutionHarnessError,
+    execute_tool_invocation,
+)
+from src.application.tools.tool_invocation_contract import ToolInvocationRequest
+from src.application.tools.tool_registry import ToolDefinition
+from src.application.tools.unit_conversion_tool import TOOL_ID as UNIT_CONVERSION_TOOL_ID
+
+
+def _request(tool_id: str, arguments: dict, request_id: str = "req-001"):
+    return ToolInvocationRequest(
+        request_id=request_id,
+        tool_id=tool_id,
+        arguments=arguments,
+        correlation_id="chat-001",
+        requested_by="test",
+    )
+
+
+def test_valid_calculator_request_executes_successfully():
+    response = execute_tool_invocation(
+        _request(
+            CALCULATOR_TOOL_ID,
+            {"operation": "add", "operands": [1, 2]},
+        )
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "success"
+    assert out["request_id"] == "req-001"
+    assert out["tool_id"] == CALCULATOR_TOOL_ID
+    assert out["correlation_id"] == "chat-001"
+    assert out["result"]["computed_result"] == "3"
+    assert out["result"]["can_govern_truth"] is False
+    assert out["error"] is None
+    assert out["can_govern_truth"] is False
+
+
+def test_valid_calculator_request_accepts_inputs_alias():
+    response = execute_tool_invocation(
+        _request(
+            CALCULATOR_TOOL_ID,
+            {"operation": "multiply", "inputs": [6, 7]},
+        )
+    )
+
+    assert response.to_dict()["result"]["computed_result"] == "42"
+
+
+def test_valid_unit_conversion_request_executes_successfully():
+    response = execute_tool_invocation(
+        _request(
+            UNIT_CONVERSION_TOOL_ID,
+            {
+                "value": 1,
+                "from_unit": "m",
+                "to_unit": "cm",
+                "dimension": "length",
+            },
+            request_id="req-002",
+        )
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "success"
+    assert out["request_id"] == "req-002"
+    assert out["tool_id"] == UNIT_CONVERSION_TOOL_ID
+    assert out["result"]["converted_value"] == "100"
+    assert out["can_govern_truth"] is False
+
+
+def test_valid_quantity_formula_request_executes_successfully():
+    response = execute_tool_invocation(
+        _request(
+            QUANTITY_FORMULA_TOOL_ID,
+            {
+                "formula_id": "rectangle_area",
+                "inputs": {"length": 2, "width": 3},
+            },
+            request_id="req-003",
+        )
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "success"
+    assert out["request_id"] == "req-003"
+    assert out["tool_id"] == QUANTITY_FORMULA_TOOL_ID
+    assert out["result"]["computed_result"] == "6"
+    assert out["can_govern_truth"] is False
+
+
+def test_unknown_tool_returns_controlled_error_without_execution():
+    called = {"value": False}
+
+    def blocked_executor(arguments):
+        called["value"] = True
+        return {"bad": True}
+
+    response = execute_tool_invocation(
+        _request("unknown.local", {"operation": "add"}),
+        executors={"unknown.local": blocked_executor},
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["result"] is None
+    assert out["error"]["error_type"] == "tool_not_eligible"
+    assert called["value"] is False
+    assert out["can_govern_truth"] is False
+
+
+def test_ineligible_tool_returns_controlled_error_and_does_not_execute():
+    base = calculator_tool_definition()
+    disabled = ToolDefinition(
+        tool_id=base.tool_id,
+        display_name=base.display_name,
+        description=base.description,
+        input_schema=base.input_schema,
+        output_schema=base.output_schema,
+        authority_level=base.authority_level,
+        scope=base.scope,
+        side_effects=base.side_effects,
+        requires_consent=base.requires_consent,
+        can_govern_truth=base.can_govern_truth,
+        audit_log_required=base.audit_log_required,
+        enabled_by_default=False,
+        requires_project=base.requires_project,
+        requires_snapshot=base.requires_snapshot,
+        result_provenance_required=base.result_provenance_required,
+    )
+
+    called = {"value": False}
+
+    def blocked_executor(arguments):
+        called["value"] = True
+        return {"bad": True}
+
+    response = execute_tool_invocation(
+        _request(CALCULATOR_TOOL_ID, {"operation": "add", "operands": [1, 2]}),
+        executors={CALCULATOR_TOOL_ID: blocked_executor},
+        definition_factories={CALCULATOR_TOOL_ID: lambda: disabled},
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["error"]["error_type"] == "tool_not_eligible"
+    assert "tool_disabled" in out["error"]["details"]["reasons"]
+    assert called["value"] is False
+
+
+def test_bad_arguments_return_controlled_error_response():
+    response = execute_tool_invocation(
+        _request(CALCULATOR_TOOL_ID, {"operation": "add"})
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["result"] is None
+    assert out["error"]["error_type"] == "tool_execution_error"
+    assert "operands or inputs" in out["error"]["message"]
+
+
+def test_tool_implementation_error_returns_controlled_error_response():
+    def failing_executor(arguments):
+        raise RuntimeError("boom")
+
+    response = execute_tool_invocation(
+        _request(CALCULATOR_TOOL_ID, {"operation": "add", "operands": [1, 2]}),
+        executors={CALCULATOR_TOOL_ID: failing_executor},
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["result"] is None
+    assert out["error"]["error_type"] == "tool_execution_error"
+    assert out["error"]["message"] == "boom"
+    assert out["can_govern_truth"] is False
+
+
+def test_request_must_be_tool_invocation_request():
+    with pytest.raises(ToolExecutionHarnessError, match="ToolInvocationRequest"):
+        execute_tool_invocation({"tool_id": CALCULATOR_TOOL_ID})
+
+
+def test_invalid_request_returns_controlled_error_response():
+    response = execute_tool_invocation(
+        ToolInvocationRequest(
+            request_id="",
+            tool_id=CALCULATOR_TOOL_ID,
+            arguments={"operation": "add"},
+        )
+    )
+
+    out = response.to_dict()
+    assert out["status"] == "error"
+    assert out["error"]["error_type"] == "invalid_request"
+    assert out["can_govern_truth"] is False
+
+
+def test_success_and_error_responses_are_json_serializable():
+    success = execute_tool_invocation(
+        _request(CALCULATOR_TOOL_ID, {"operation": "add", "operands": [1, 2]})
+    )
+    error = execute_tool_invocation(
+        _request("unknown.local", {"operation": "add"})
+    )
+
+    assert json.loads(json.dumps(success.to_dict(), sort_keys=True)) == success.to_dict()
+    assert json.loads(json.dumps(error.to_dict(), sort_keys=True)) == error.to_dict()
+
+
+def test_all_responses_keep_truth_governance_false():
+    responses = [
+        execute_tool_invocation(
+            _request(CALCULATOR_TOOL_ID, {"operation": "add", "operands": [1, 2]})
+        ),
+        execute_tool_invocation(_request("unknown.local", {"operation": "add"})),
+        execute_tool_invocation(_request(CALCULATOR_TOOL_ID, {"operation": "add"})),
+    ]
+
+    for response in responses:
+        assert response.to_dict()["can_govern_truth"] is False


### PR DESCRIPTION
## Summary

Adds a bounded execution harness for application-owned deterministic local tools.

This is the first controlled execution step, but it is not chat integration, not an autonomous router, and not an LLM tool-calling system. It executes only already-registered deterministic local tools after request validation, resolver/eligibility checks, and explicit argument adaptation.

## Scope

Added:

- `src/application/tools/tool_execution_harness.py`
- `src/tests/test_tool_execution_harness_contract.py`

## What this provides

- `ToolExecutionHarnessError`
- `execute_tool_invocation(...)`
- Explicit executor mapping for:
  - `calculator.local`
  - `unit_conversion.local`
  - `quantity_formula.local`
- Request validation using `ToolInvocationRequest.validate()`
- Eligibility gating before execution
- Controlled `ToolInvocationResponse` success/error envelopes
- Explicit argument adaptation per supported deterministic tool
- Controlled errors for:
  - invalid request
  - tool resolution error
  - ineligible tool
  - missing executor
  - bad arguments
  - implementation exception
- Tests proving unknown/ineligible tools do not execute
- Tests proving responses remain JSON-serializable and non-truth-governing

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_registry.py src\application\tools\tool_invocation_contract.py src\application\tools\tool_resolver.py src\application\tools\tool_eligibility_gate.py src\application\tools\tool_execution_harness.py src\tests\test_tool_execution_harness_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py
101 passed in 0.20s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No file writes
- No DB writes
- No audit persistence implementation
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No UI changes
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium if widened later; this PR remains harness-only
- Product risk: reduced by requiring resolver and eligibility checks before deterministic execution

Related: issue #64.