### PR TITLE
Add tool execution audit event contract

### DIFF
--- a/src/application/tools/tool_execution_audit.py
+++ b/src/application/tools/tool_execution_audit.py
@@ -1,0 +1,162 @@
+﻿"""Non-persistent audit event contract for deterministic tool executions.
+
+This module builds JSON-safe audit event envelopes only. It does not persist
+events, write files, touch databases, execute tools, wire chat/router behavior,
+or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.application.tools.tool_eligibility_gate import ToolEligibility
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationRequest,
+    ToolInvocationResponse,
+)
+
+
+class ToolExecutionAuditContractError(ValueError):
+    """Raised when a tool execution audit event contract is invalid."""
+
+
+@dataclass(frozen=True)
+class ToolExecutionAuditEvent:
+    """Plain non-persistent audit event envelope."""
+
+    event_type: str
+    event_id: str
+    request_id: str
+    tool_id: str
+    correlation_id: str | None
+    requested_by: str
+    consent_granted: bool
+    response_status: str
+    eligibility_decision: str | None
+    eligibility_reasons: tuple[str, ...]
+    error_type: str | None
+    can_govern_truth: bool
+    event_source: str
+    created_at: str | None
+
+    def validate(self) -> None:
+        _require_non_empty(self.event_type, "event_type")
+        _require_non_empty(self.event_id, "event_id")
+        _require_non_empty(self.request_id, "request_id")
+        _require_non_empty(self.tool_id, "tool_id")
+        _require_non_empty(self.requested_by, "requested_by")
+        _require_non_empty(self.response_status, "response_status")
+        _require_non_empty(self.event_source, "event_source")
+
+        if self.can_govern_truth is not False:
+            raise ToolExecutionAuditContractError(
+                "Tool execution audit events cannot govern truth."
+            )
+        if not isinstance(self.consent_granted, bool):
+            raise ToolExecutionAuditContractError("consent_granted must be boolean.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "event_type": self.event_type,
+            "event_id": self.event_id,
+            "request_id": self.request_id,
+            "tool_id": self.tool_id,
+            "correlation_id": self.correlation_id,
+            "requested_by": self.requested_by,
+            "consent_granted": self.consent_granted,
+            "response_status": self.response_status,
+            "eligibility_decision": self.eligibility_decision,
+            "eligibility_reasons": list(self.eligibility_reasons),
+            "error_type": self.error_type,
+            "can_govern_truth": False,
+            "event_source": self.event_source,
+            "created_at": self.created_at,
+        }
+
+
+def build_tool_execution_audit_event(
+    *,
+    request: ToolInvocationRequest,
+    response: ToolInvocationResponse,
+    eligibility: ToolEligibility | Mapping[str, Any] | None = None,
+    event_id: str | None = None,
+    created_at: str | None = None,
+    event_source: str = "tool_execution_harness",
+) -> ToolExecutionAuditEvent:
+    """Build a non-persistent audit event without executing or persisting anything."""
+
+    if not isinstance(request, ToolInvocationRequest):
+        raise ToolExecutionAuditContractError(
+            "request must be a ToolInvocationRequest instance."
+        )
+    if not isinstance(response, ToolInvocationResponse):
+        raise ToolExecutionAuditContractError(
+            "response must be a ToolInvocationResponse instance."
+        )
+
+    request.validate()
+    response.validate()
+
+    if request.request_id != response.request_id:
+        raise ToolExecutionAuditContractError(
+            "request and response request_id values must match."
+        )
+    if request.tool_id != response.tool_id:
+        raise ToolExecutionAuditContractError(
+            "request and response tool_id values must match."
+        )
+
+    eligibility_dict = _eligibility_to_dict(eligibility)
+    response_dict = response.to_dict()
+    error = response_dict.get("error") or {}
+
+    normalized_event_id = event_id or _derive_event_id(
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        response_status=response_dict["status"],
+    )
+
+    event = ToolExecutionAuditEvent(
+        event_type="tool_execution.completed",
+        event_id=_require_non_empty(normalized_event_id, "event_id"),
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        correlation_id=request.correlation_id,
+        requested_by=request.requested_by,
+        consent_granted=request.consent_granted,
+        response_status=response_dict["status"],
+        eligibility_decision=eligibility_dict.get("decision"),
+        eligibility_reasons=tuple(eligibility_dict.get("reasons") or ()),
+        error_type=error.get("error_type"),
+        can_govern_truth=False,
+        event_source=_require_non_empty(event_source, "event_source"),
+        created_at=created_at,
+    )
+    event.validate()
+    return event
+
+
+def _eligibility_to_dict(
+    eligibility: ToolEligibility | Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    if eligibility is None:
+        return {}
+    if isinstance(eligibility, ToolEligibility):
+        return eligibility.to_dict()
+    if isinstance(eligibility, Mapping):
+        return dict(eligibility)
+    raise ToolExecutionAuditContractError(
+        "eligibility must be ToolEligibility, mapping, or None."
+    )
+
+
+def _derive_event_id(*, request_id: str, tool_id: str, response_status: str) -> str:
+    return f"tool-execution:{request_id}:{tool_id}:{response_status}"
+
+
+def _require_non_empty(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ToolExecutionAuditContractError(f"{field_name} must be a non-empty string.")
+    return value.strip()

--- a/src/tests/test_tool_execution_audit_contract.py
+++ b/src/tests/test_tool_execution_audit_contract.py
@@ -1,0 +1,244 @@
+﻿from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_eligibility_gate import check_tool_eligibility
+from src.application.tools.tool_execution_audit import (
+    ToolExecutionAuditContractError,
+    build_tool_execution_audit_event,
+)
+from src.application.tools.tool_execution_harness import execute_tool_invocation
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationRequest,
+    ToolInvocationResponse,
+    ToolInvocationStatus,
+)
+
+
+def _request(tool_id: str = CALCULATOR_TOOL_ID, request_id: str = "req-001"):
+    return ToolInvocationRequest(
+        request_id=request_id,
+        tool_id=tool_id,
+        arguments={"operation": "add", "operands": [1, 2]},
+        correlation_id="chat-001",
+        requested_by="test",
+        consent_granted=False,
+    )
+
+
+def test_successful_tool_response_can_produce_audit_event():
+    request = _request()
+    response = execute_tool_invocation(request)
+    eligibility = check_tool_eligibility(request.tool_id)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        eligibility=eligibility,
+        event_id="evt-001",
+        created_at="2026-04-28T06:00:00Z",
+    ).to_dict()
+
+    assert event == {
+        "event_type": "tool_execution.completed",
+        "event_id": "evt-001",
+        "request_id": "req-001",
+        "tool_id": CALCULATOR_TOOL_ID,
+        "correlation_id": "chat-001",
+        "requested_by": "test",
+        "consent_granted": False,
+        "response_status": "success",
+        "eligibility_decision": "allow",
+        "eligibility_reasons": ["eligible"],
+        "error_type": None,
+        "can_govern_truth": False,
+        "event_source": "tool_execution_harness",
+        "created_at": "2026-04-28T06:00:00Z",
+    }
+
+
+def test_error_tool_response_can_produce_audit_event_with_error_type():
+    request = _request(tool_id="unknown.local")
+    response = execute_tool_invocation(request)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        eligibility=response.to_dict()["error"]["details"],
+        event_id="evt-002",
+    ).to_dict()
+
+    assert event["response_status"] == "error"
+    assert event["eligibility_decision"] == "deny"
+    assert "tool_not_resolved" in event["eligibility_reasons"]
+    assert event["error_type"] == "tool_not_eligible"
+    assert event["can_govern_truth"] is False
+
+
+def test_audit_event_derives_stable_event_id_when_not_supplied():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+    ).to_dict()
+
+    assert event["event_id"] == (
+        f"tool-execution:{request.request_id}:{request.tool_id}:success"
+    )
+
+
+def test_audit_event_accepts_eligibility_mapping():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        eligibility={"decision": "allow", "reasons": ["eligible"]},
+    ).to_dict()
+
+    assert event["eligibility_decision"] == "allow"
+    assert event["eligibility_reasons"] == ["eligible"]
+
+
+def test_audit_event_allows_missing_eligibility_for_legacy_callers():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+    ).to_dict()
+
+    assert event["eligibility_decision"] is None
+    assert event["eligibility_reasons"] == []
+
+
+def test_request_response_request_id_mismatch_is_rejected():
+    request = _request(request_id="req-001")
+    response = ToolInvocationResponse(
+        request_id="req-002",
+        tool_id=request.tool_id,
+        status=ToolInvocationStatus.SUCCESS,
+        result={"ok": True},
+        can_govern_truth=False,
+    )
+
+    with pytest.raises(ToolExecutionAuditContractError, match="request_id"):
+        build_tool_execution_audit_event(request=request, response=response)
+
+
+def test_request_response_tool_id_mismatch_is_rejected():
+    request = _request(tool_id=CALCULATOR_TOOL_ID)
+    response = ToolInvocationResponse(
+        request_id=request.request_id,
+        tool_id="unit_conversion.local",
+        status=ToolInvocationStatus.SUCCESS,
+        result={"ok": True},
+        can_govern_truth=False,
+    )
+
+    with pytest.raises(ToolExecutionAuditContractError, match="tool_id"):
+        build_tool_execution_audit_event(request=request, response=response)
+
+
+def test_audit_event_is_json_serializable():
+    request = _request()
+    response = execute_tool_invocation(request)
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        eligibility=check_tool_eligibility(request.tool_id),
+    ).to_dict()
+
+    assert json.loads(json.dumps(event, sort_keys=True)) == event
+
+
+def test_audit_event_does_not_include_raw_result_payload_by_default():
+    request = _request()
+    response = execute_tool_invocation(request)
+    event = build_tool_execution_audit_event(request=request, response=response).to_dict()
+
+    assert "result" not in event
+    assert "response" not in event
+
+
+def test_audit_event_cannot_govern_truth():
+    request = _request()
+    response = execute_tool_invocation(request)
+    event = build_tool_execution_audit_event(request=request, response=response)
+
+    assert event.to_dict()["can_govern_truth"] is False
+
+
+def test_invalid_event_id_is_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="event_id"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            event_id="   ",
+        )
+
+
+def test_invalid_event_source_is_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="event_source"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            event_source="",
+        )
+
+
+def test_audit_builder_rejects_non_request_input():
+    response = execute_tool_invocation(_request())
+
+    with pytest.raises(ToolExecutionAuditContractError, match="request"):
+        build_tool_execution_audit_event(
+            request={"bad": True},
+            response=response,
+        )
+
+
+def test_audit_builder_rejects_non_response_input():
+    request = _request()
+
+    with pytest.raises(ToolExecutionAuditContractError, match="response"):
+        build_tool_execution_audit_event(
+            request=request,
+            response={"bad": True},
+        )
+
+
+def test_audit_builder_does_not_execute_tools(monkeypatch):
+    request = _request()
+    response = execute_tool_invocation(request)
+    called = {"value": False}
+
+    def blocked_execute_tool_invocation(*args, **kwargs):
+        called["value"] = True
+        raise AssertionError("audit builder must not execute tools")
+
+    monkeypatch.setattr(
+        "src.application.tools.tool_execution_harness.execute_tool_invocation",
+        blocked_execute_tool_invocation,
+    )
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        eligibility={"decision": "allow", "reasons": ["eligible"]},
+    )
+
+    assert event.to_dict()["request_id"] == request.request_id
+    assert called["value"] is False


### PR DESCRIPTION
## Summary

Adds a bounded, non-persistent audit event contract for deterministic tool executions.

This defines only the stable audit event shape that future audit persistence may use after explicit approval. It does not persist events, write files, touch databases, execute tools, wire chat/router behavior, or interact with UI/runtime providers.

## Scope

Added:

- `src/application/tools/tool_execution_audit.py`
- `src/tests/test_tool_execution_audit_contract.py`

## What this provides

- `ToolExecutionAuditContractError`
- `ToolExecutionAuditEvent`
- `build_tool_execution_audit_event(...)`
- Stable JSON-safe event envelope with:
  - event type
  - event ID
  - request ID
  - tool ID
  - correlation ID
  - requested_by
  - consent state
  - response status
  - eligibility decision/reasons
  - response error type
  - event source
  - created_at
  - non-truth-governing posture
- Request/response correlation validation
- Optional deterministic/injected event ID and timestamp
- Tests proving successful and failed executions can produce audit events
- Tests proving raw result/response payloads are not included by default
- Tests proving audit builder does not execute tools

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_invocation_contract.py src\application\tools\tool_eligibility_gate.py src\application\tools\tool_execution_harness.py src\application\tools\tool_execution_audit.py src\tests\test_tool_execution_audit_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py
116 passed in 0.24s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No DB writes
- No file writes
- No audit persistence implementation
- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium if widened later; this PR remains non-persistent audit-event contract only
- Product risk: reduced by defining auditability before chat/tool integration

Related: issue #66.