### PR TITLE
Fix tool execution audit validation

### DIFF
--- a/src/application/tools/tool_execution_audit.py
+++ b/src/application/tools/tool_execution_audit.py
@@ -7,6 +7,7 @@ or interact with UI/runtime providers.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Mapping
 
@@ -48,6 +49,7 @@ class ToolExecutionAuditEvent:
         _require_non_empty(self.requested_by, "requested_by")
         _require_non_empty(self.response_status, "response_status")
         _require_non_empty(self.event_source, "event_source")
+        _validate_optional_string(self.created_at, "created_at")
 
         if self.can_govern_truth is not False:
             raise ToolExecutionAuditContractError(
@@ -107,6 +109,10 @@ def build_tool_execution_audit_event(
         raise ToolExecutionAuditContractError(
             "request and response tool_id values must match."
         )
+    if request.correlation_id != response.correlation_id:
+        raise ToolExecutionAuditContractError(
+            "request and response correlation_id values must match."
+        )
 
     eligibility_dict = _eligibility_to_dict(eligibility)
     response_dict = response.to_dict()
@@ -128,11 +134,11 @@ def build_tool_execution_audit_event(
         consent_granted=request.consent_granted,
         response_status=response_dict["status"],
         eligibility_decision=eligibility_dict.get("decision"),
-        eligibility_reasons=tuple(eligibility_dict.get("reasons") or ()),
+        eligibility_reasons=_normalize_reasons(eligibility_dict.get("reasons")),
         error_type=error.get("error_type"),
         can_govern_truth=False,
         event_source=_require_non_empty(event_source, "event_source"),
-        created_at=created_at,
+        created_at=_validate_optional_string(created_at, "created_at"),
     )
     event.validate()
     return event
@@ -152,9 +158,39 @@ def _eligibility_to_dict(
     )
 
 
+def _normalize_reasons(raw_reasons: Any) -> tuple[str, ...]:
+    if raw_reasons is None:
+        return ()
+    if isinstance(raw_reasons, str):
+        raise ToolExecutionAuditContractError(
+            "eligibility reasons must be a sequence of non-empty strings, not a string."
+        )
+    if not isinstance(raw_reasons, Sequence):
+        raise ToolExecutionAuditContractError(
+            "eligibility reasons must be a sequence of non-empty strings."
+        )
+
+    reasons: list[str] = []
+    for reason in raw_reasons:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ToolExecutionAuditContractError(
+                "eligibility reasons must contain only non-empty strings."
+            )
+        reasons.append(reason.strip())
+    return tuple(reasons)
+
 def _derive_event_id(*, request_id: str, tool_id: str, response_status: str) -> str:
     return f"tool-execution:{request_id}:{tool_id}:{response_status}"
 
+
+def _validate_optional_string(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ToolExecutionAuditContractError(
+            f"{field_name} must be None or a non-empty string."
+        )
+    return value.strip()
 
 def _require_non_empty(value: Any, field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():

--- a/src/tests/test_tool_execution_audit_contract.py
+++ b/src/tests/test_tool_execution_audit_contract.py
@@ -147,6 +147,56 @@ def test_request_response_tool_id_mismatch_is_rejected():
         build_tool_execution_audit_event(request=request, response=response)
 
 
+def test_request_response_correlation_id_mismatch_is_rejected():
+    request = _request()
+    response = ToolInvocationResponse(
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        status=ToolInvocationStatus.SUCCESS,
+        result={"ok": True},
+        correlation_id="different-correlation",
+        can_govern_truth=False,
+    )
+
+    with pytest.raises(ToolExecutionAuditContractError, match="correlation_id"):
+        build_tool_execution_audit_event(request=request, response=response)
+
+
+def test_string_eligibility_reasons_are_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="eligibility reasons"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            eligibility={"decision": "deny", "reasons": "tool_disabled"},
+        )
+
+
+def test_non_sequence_eligibility_reasons_are_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="eligibility reasons"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            eligibility={"decision": "deny", "reasons": 123},
+        )
+
+
+def test_blank_eligibility_reason_is_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="eligibility reasons"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            eligibility={"decision": "deny", "reasons": ["tool_disabled", " "]},
+        )
+
 def test_audit_event_is_json_serializable():
     request = _request()
     response = execute_tool_invocation(request)
@@ -175,6 +225,44 @@ def test_audit_event_cannot_govern_truth():
 
     assert event.to_dict()["can_govern_truth"] is False
 
+
+def test_invalid_created_at_type_is_rejected():
+    from datetime import datetime
+
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="created_at"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            created_at=datetime.utcnow(),
+        )
+
+
+def test_blank_created_at_is_rejected():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    with pytest.raises(ToolExecutionAuditContractError, match="created_at"):
+        build_tool_execution_audit_event(
+            request=request,
+            response=response,
+            created_at="   ",
+        )
+
+
+def test_created_at_is_trimmed_when_valid():
+    request = _request()
+    response = execute_tool_invocation(request)
+
+    event = build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        created_at="  2026-04-28T06:00:00Z  ",
+    ).to_dict()
+
+    assert event["created_at"] == "2026-04-28T06:00:00Z"
 
 def test_invalid_event_id_is_rejected():
     request = _request()


### PR DESCRIPTION
## Summary

Follow-up fix for the tool execution audit event contract after review feedback on PR #67.

PR #67 merged the base non-persistent audit event contract. This follow-up PR applies the two audit-validation corrections that were made on the branch after the original PR had already merged.

## Fixes

- Enforces `correlation_id` parity between `ToolInvocationRequest` and `ToolInvocationResponse` before building audit events.
- Rejects invalid mapping-shaped eligibility `reasons`, including string values, non-sequences, and blank/non-string reasons.

## Verification

Local Windows verification on the corrected branch:

```text
py -m py_compile src\application\tools\tool_invocation_contract.py src\application\tools\tool_eligibility_gate.py src\application\tools\tool_execution_harness.py src\application\tools\tool_execution_audit.py src\tests\test_tool_execution_audit_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py
120 passed in 0.23s
```

Packaging boundary:

```text
git diff --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

Diff hygiene:

```text
git diff --check
# only line-ending warnings before staging; git diff --cached --check passed with no output
```

## Non-scope preserved

- No DB writes
- No file writes
- No audit persistence implementation
- No chat wiring
- No autonomous tool router
- No LLM parser
- No MCP integration
- No agent loop
- No internet use
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new tool behavior
- No packaging changes
- No dependency changes

Related: issue #66, PR #67.