### PR TITLE
Add non-writing tool execution audit sink

### DIFF
--- a/src/application/tools/tool_execution_audit_sink.py
+++ b/src/application/tools/tool_execution_audit_sink.py
@@ -1,0 +1,173 @@
+"""Non-writing sink contract for tool execution audit events.
+
+This module defines deterministic sink semantics only. It does not persist
+events, write files, touch databases, execute tools, wire chat/router behavior,
+or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from src.application.tools.tool_execution_audit import ToolExecutionAuditEvent
+
+
+class ToolExecutionAuditSinkContractError(ValueError):
+    """Raised when a tool execution audit sink contract is invalid."""
+
+
+@dataclass(frozen=True)
+class ToolExecutionAuditSinkResult:
+    """JSON-safe result envelope returned by audit sinks."""
+
+    sink_name: str
+    accepted: bool
+    event_id: str | None
+    request_id: str | None
+    tool_id: str | None
+    response_status: str | None
+    error: dict[str, Any] | None
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        _require_non_empty(self.sink_name, "sink_name")
+        if not isinstance(self.accepted, bool):
+            raise ToolExecutionAuditSinkContractError("accepted must be boolean.")
+        if self.can_govern_truth is not False:
+            raise ToolExecutionAuditSinkContractError(
+                "Tool execution audit sink results cannot govern truth."
+            )
+        if self.accepted and self.error is not None:
+            raise ToolExecutionAuditSinkContractError(
+                "Accepted sink results must not include an error."
+            )
+        if not self.accepted and not isinstance(self.error, dict):
+            raise ToolExecutionAuditSinkContractError(
+                "Rejected sink results must include a controlled error mapping."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "sink_name": self.sink_name,
+            "accepted": self.accepted,
+            "event_id": self.event_id,
+            "request_id": self.request_id,
+            "tool_id": self.tool_id,
+            "response_status": self.response_status,
+            "error": self.error,
+            "can_govern_truth": False,
+        }
+
+
+class ToolExecutionAuditSink(Protocol):
+    """Protocol for non-writing audit event sinks."""
+
+    @property
+    def sink_name(self) -> str:
+        """Return deterministic sink name."""
+
+    def accept(self, event: ToolExecutionAuditEvent) -> ToolExecutionAuditSinkResult:
+        """Accept an audit event and return a deterministic sink result."""
+
+
+class NoopToolExecutionAuditSink:
+    """Production-safe no-op sink that validates but does not store events."""
+
+    sink_name = "noop_tool_execution_audit_sink"
+
+    def accept(self, event: ToolExecutionAuditEvent) -> ToolExecutionAuditSinkResult:
+        try:
+            event_dict = _validated_event_dict(event)
+        except ToolExecutionAuditSinkContractError as exc:
+            return _error_result(self.sink_name, "invalid_event", str(exc))
+
+        return ToolExecutionAuditSinkResult(
+            sink_name=self.sink_name,
+            accepted=True,
+            event_id=event_dict["event_id"],
+            request_id=event_dict["request_id"],
+            tool_id=event_dict["tool_id"],
+            response_status=event_dict["response_status"],
+            error=None,
+            can_govern_truth=False,
+        )
+
+
+class InMemoryToolExecutionAuditSink:
+    """Test-only in-memory sink. It performs no DB/file writes."""
+
+    sink_name = "in_memory_tool_execution_audit_sink"
+
+    def __init__(self) -> None:
+        self._events: list[dict[str, Any]] = []
+
+    def accept(self, event: ToolExecutionAuditEvent) -> ToolExecutionAuditSinkResult:
+        try:
+            event_dict = _validated_event_dict(event)
+        except ToolExecutionAuditSinkContractError as exc:
+            return _error_result(self.sink_name, "invalid_event", str(exc))
+
+        self._events.append(dict(event_dict))
+        return ToolExecutionAuditSinkResult(
+            sink_name=self.sink_name,
+            accepted=True,
+            event_id=event_dict["event_id"],
+            request_id=event_dict["request_id"],
+            tool_id=event_dict["tool_id"],
+            response_status=event_dict["response_status"],
+            error=None,
+            can_govern_truth=False,
+        )
+
+    def events(self) -> tuple[dict[str, Any], ...]:
+        """Return immutable snapshot of accepted event dictionaries."""
+        return tuple(dict(event) for event in self._events)
+
+
+def accept_tool_execution_audit_event(
+    sink: ToolExecutionAuditSink,
+    event: ToolExecutionAuditEvent,
+) -> ToolExecutionAuditSinkResult:
+    """Accept an audit event through a sink protocol implementation."""
+
+    if not hasattr(sink, "accept"):
+        raise ToolExecutionAuditSinkContractError("sink must implement accept(event).")
+    return sink.accept(event)
+
+
+def _validated_event_dict(event: ToolExecutionAuditEvent) -> dict[str, Any]:
+    if not isinstance(event, ToolExecutionAuditEvent):
+        raise ToolExecutionAuditSinkContractError(
+            "event must be a ToolExecutionAuditEvent instance."
+        )
+    return event.to_dict()
+
+
+def _error_result(
+    sink_name: str,
+    error_type: str,
+    message: str,
+) -> ToolExecutionAuditSinkResult:
+    return ToolExecutionAuditSinkResult(
+        sink_name=sink_name,
+        accepted=False,
+        event_id=None,
+        request_id=None,
+        tool_id=None,
+        response_status=None,
+        error={
+            "error_type": error_type,
+            "message": message,
+        },
+        can_govern_truth=False,
+    )
+
+
+def _require_non_empty(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ToolExecutionAuditSinkContractError(
+            f"{field_name} must be a non-empty string."
+        )
+    return value.strip()

--- a/src/tests/test_tool_execution_audit_sink_contract.py
+++ b/src/tests/test_tool_execution_audit_sink_contract.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_execution_audit import (
+    build_tool_execution_audit_event,
+)
+from src.application.tools.tool_execution_audit_sink import (
+    InMemoryToolExecutionAuditSink,
+    NoopToolExecutionAuditSink,
+    ToolExecutionAuditSinkContractError,
+    ToolExecutionAuditSinkResult,
+    accept_tool_execution_audit_event,
+)
+from src.application.tools.tool_execution_harness import execute_tool_invocation
+from src.application.tools.tool_invocation_contract import ToolInvocationRequest
+
+
+def _request():
+    return ToolInvocationRequest(
+        request_id="req-001",
+        tool_id=CALCULATOR_TOOL_ID,
+        arguments={"operation": "add", "operands": [1, 2]},
+        correlation_id="chat-001",
+        requested_by="test",
+        consent_granted=False,
+    )
+
+
+def _audit_event():
+    request = _request()
+    response = execute_tool_invocation(request)
+    return build_tool_execution_audit_event(
+        request=request,
+        response=response,
+        event_id="evt-001",
+        created_at="2026-04-28T06:00:00Z",
+    )
+
+
+def test_noop_sink_accepts_valid_audit_event_without_storage():
+    sink = NoopToolExecutionAuditSink()
+    result = sink.accept(_audit_event()).to_dict()
+
+    assert result == {
+        "sink_name": "noop_tool_execution_audit_sink",
+        "accepted": True,
+        "event_id": "evt-001",
+        "request_id": "req-001",
+        "tool_id": CALCULATOR_TOOL_ID,
+        "response_status": "success",
+        "error": None,
+        "can_govern_truth": False,
+    }
+    assert not hasattr(sink, "_events")
+
+
+def test_in_memory_sink_accepts_valid_audit_event_in_process_only():
+    sink = InMemoryToolExecutionAuditSink()
+    event = _audit_event()
+
+    result = sink.accept(event).to_dict()
+
+    assert result["accepted"] is True
+    assert result["sink_name"] == "in_memory_tool_execution_audit_sink"
+    assert result["event_id"] == "evt-001"
+    assert len(sink.events()) == 1
+    assert sink.events()[0]["event_id"] == "evt-001"
+
+
+def test_in_memory_events_returns_snapshot_not_mutable_store():
+    sink = InMemoryToolExecutionAuditSink()
+    sink.accept(_audit_event())
+
+    snapshot = sink.events()
+    snapshot[0]["event_id"] = "mutated"
+
+    assert sink.events()[0]["event_id"] == "evt-001"
+
+
+def test_accept_helper_uses_sink_protocol():
+    result = accept_tool_execution_audit_event(
+        NoopToolExecutionAuditSink(),
+        _audit_event(),
+    ).to_dict()
+
+    assert result["accepted"] is True
+    assert result["sink_name"] == "noop_tool_execution_audit_sink"
+
+
+def test_accept_helper_rejects_object_without_accept():
+    with pytest.raises(ToolExecutionAuditSinkContractError, match="accept"):
+        accept_tool_execution_audit_event(object(), _audit_event())
+
+
+@pytest.mark.parametrize(
+    "sink",
+    [NoopToolExecutionAuditSink(), InMemoryToolExecutionAuditSink()],
+)
+def test_sinks_reject_raw_dict_event_with_controlled_error(sink):
+    result = sink.accept({"event_id": "evt-001"}).to_dict()
+
+    assert result["accepted"] is False
+    assert result["error"]["error_type"] == "invalid_event"
+    assert "ToolExecutionAuditEvent" in result["error"]["message"]
+    assert result["can_govern_truth"] is False
+
+
+def test_sink_result_is_json_serializable():
+    result = NoopToolExecutionAuditSink().accept(_audit_event()).to_dict()
+
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_sink_result_cannot_govern_truth():
+    with pytest.raises(ToolExecutionAuditSinkContractError, match="cannot govern truth"):
+        ToolExecutionAuditSinkResult(
+            sink_name="bad_sink",
+            accepted=True,
+            event_id="evt-001",
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            error=None,
+            can_govern_truth=True,
+        ).to_dict()
+
+
+def test_accepted_sink_result_cannot_include_error():
+    with pytest.raises(ToolExecutionAuditSinkContractError, match="must not include an error"):
+        ToolExecutionAuditSinkResult(
+            sink_name="bad_sink",
+            accepted=True,
+            event_id="evt-001",
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            error={"error_type": "bad"},
+            can_govern_truth=False,
+        ).to_dict()
+
+
+def test_rejected_sink_result_must_include_error_mapping():
+    with pytest.raises(ToolExecutionAuditSinkContractError, match="must include"):
+        ToolExecutionAuditSinkResult(
+            sink_name="bad_sink",
+            accepted=False,
+            event_id=None,
+            request_id=None,
+            tool_id=None,
+            response_status=None,
+            error=None,
+            can_govern_truth=False,
+        ).to_dict()
+
+
+def test_invalid_sink_name_is_rejected():
+    with pytest.raises(ToolExecutionAuditSinkContractError, match="sink_name"):
+        ToolExecutionAuditSinkResult(
+            sink_name="",
+            accepted=True,
+            event_id="evt-001",
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            error=None,
+            can_govern_truth=False,
+        ).to_dict()
+
+
+def test_sink_interface_does_not_execute_tools(monkeypatch):
+    event = _audit_event()
+    called = {"value": False}
+
+    def blocked_execute_tool_invocation(*args, **kwargs):
+        called["value"] = True
+        raise AssertionError("sink must not execute tools")
+
+    monkeypatch.setattr(
+        "src.application.tools.tool_execution_harness.execute_tool_invocation",
+        blocked_execute_tool_invocation,
+    )
+
+    result = NoopToolExecutionAuditSink().accept(event).to_dict()
+
+    assert result["accepted"] is True
+    assert called["value"] is False


### PR DESCRIPTION
## Summary

Adds a bounded, non-writing sink interface for tool execution audit events.

This defines deterministic sink semantics only. It does not persist events, write files, touch databases, execute tools, wire chat/router behavior, or interact with UI/runtime providers.

## Scope

Added:

- `src/application/tools/tool_execution_audit_sink.py`
- `src/tests/test_tool_execution_audit_sink_contract.py`

## What this provides

- `ToolExecutionAuditSinkContractError`
- `ToolExecutionAuditSinkResult`
- `ToolExecutionAuditSink` protocol
- `NoopToolExecutionAuditSink`
- `InMemoryToolExecutionAuditSink`
- `accept_tool_execution_audit_event(...)`
- Controlled invalid-event error envelopes
- JSON-safe sink-result envelopes
- Non-truth-governing sink responses
- Tests proving no-op sink does not store events
- Tests proving in-memory sink stores only in process memory
- Tests proving sinks reject raw dict events with controlled errors
- Tests proving sink interface does not execute tools

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_execution_audit.py src\application\tools\tool_execution_audit_sink.py src\tests\test_tool_execution_audit_sink_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py
136 passed in 0.31s
```

Staged diff hygiene:

```text
git diff --cached --check
# no output
```

Packaging boundary:

```text
git diff --cached --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

## Non-scope preserved

- No DB writes
- No file writes
- No audit persistence implementation
- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new tool behavior
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium if widened later; this PR remains sink-interface-only
- Product risk: reduced by defining sink semantics before DB/file audit persistence

Related: issue #69.