### PR TITLE
Add tool execution audit orchestrator

### DIFF
--- a/src/application/tools/tool_execution_orchestrator.py
+++ b/src/application/tools/tool_execution_orchestrator.py
@@ -1,0 +1,242 @@
+"""Non-chat orchestration contract for deterministic tool execution with audit.
+
+This module composes existing contracts only. It does not parse LLM tool calls,
+wire chat/router behavior, persist audit events, write files, touch databases,
+or interact with UI/runtime providers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.application.tools.tool_execution_audit import (
+    ToolExecutionAuditContractError,
+    build_tool_execution_audit_event,
+)
+from src.application.tools.tool_execution_audit_sink import (
+    NoopToolExecutionAuditSink,
+    ToolExecutionAuditSink,
+    ToolExecutionAuditSinkContractError,
+    ToolExecutionAuditSinkResult,
+)
+from src.application.tools.tool_execution_harness import execute_tool_invocation
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationContractError,
+    ToolInvocationRequest,
+    ToolInvocationResponse,
+)
+
+
+class ToolExecutionOrchestratorContractError(ValueError):
+    """Raised when the tool execution orchestrator contract is invalid."""
+
+
+@dataclass(frozen=True)
+class ToolExecutionOrchestrationResult:
+    """Combined JSON-safe execution + audit sink result envelope."""
+
+    request_id: str
+    tool_id: str
+    response_status: str
+    audit_sink_name: str
+    audit_accepted: bool
+    tool_response: Mapping[str, Any]
+    audit_sink_result: Mapping[str, Any]
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        _require_non_empty(self.request_id, "request_id")
+        _require_non_empty(self.tool_id, "tool_id")
+        _require_non_empty(self.response_status, "response_status")
+        _require_non_empty(self.audit_sink_name, "audit_sink_name")
+
+        if not isinstance(self.audit_accepted, bool):
+            raise ToolExecutionOrchestratorContractError(
+                "audit_accepted must be boolean."
+            )
+        if self.can_govern_truth is not False:
+            raise ToolExecutionOrchestratorContractError(
+                "Tool execution orchestration results cannot govern truth."
+            )
+        if not isinstance(self.tool_response, Mapping):
+            raise ToolExecutionOrchestratorContractError(
+                "tool_response must be a mapping."
+            )
+        if not isinstance(self.audit_sink_result, Mapping):
+            raise ToolExecutionOrchestratorContractError(
+                "audit_sink_result must be a mapping."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "request_id": self.request_id,
+            "tool_id": self.tool_id,
+            "response_status": self.response_status,
+            "audit_sink_name": self.audit_sink_name,
+            "audit_accepted": self.audit_accepted,
+            "tool_response": dict(self.tool_response),
+            "audit_sink_result": dict(self.audit_sink_result),
+            "can_govern_truth": False,
+        }
+
+
+def execute_tool_with_audit(
+    request: ToolInvocationRequest,
+    *,
+    audit_sink: ToolExecutionAuditSink | None = None,
+    event_id: str | None = None,
+    created_at: str | None = None,
+    event_source: str = "tool_execution_orchestrator",
+    executors: Mapping[str, Any] | None = None,
+    definition_factories: Mapping[str, Any] | None = None,
+) -> ToolExecutionOrchestrationResult:
+    """Execute a deterministic tool and send a non-persistent audit event to a sink."""
+
+    if not isinstance(request, ToolInvocationRequest):
+        raise ToolExecutionOrchestratorContractError(
+            "request must be a ToolInvocationRequest instance."
+        )
+
+    sink = NoopToolExecutionAuditSink() if audit_sink is None else audit_sink
+    _validate_sink(sink)
+
+    request_validation_error = _validate_request_for_orchestration(request)
+    if request_validation_error is not None:
+        return request_validation_error
+
+    tool_response = execute_tool_invocation(
+        request,
+        executors=executors,
+        definition_factories=definition_factories,
+    )
+    tool_response_dict = tool_response.to_dict()
+
+    audit_sink_result = _build_and_accept_audit_event(
+        request=request,
+        tool_response=tool_response,
+        sink=sink,
+        event_id=event_id,
+        created_at=created_at,
+        event_source=event_source,
+    )
+    audit_sink_result_dict = audit_sink_result.to_dict()
+
+    result = ToolExecutionOrchestrationResult(
+        request_id=request.request_id,
+        tool_id=request.tool_id,
+        response_status=tool_response_dict["status"],
+        audit_sink_name=audit_sink_result_dict["sink_name"],
+        audit_accepted=audit_sink_result_dict["accepted"],
+        tool_response=tool_response_dict,
+        audit_sink_result=audit_sink_result_dict,
+        can_govern_truth=False,
+    )
+    result.validate()
+    return result
+
+
+def _validate_request_for_orchestration(
+    request: ToolInvocationRequest,
+) -> ToolExecutionOrchestrationResult | None:
+    try:
+        request_dict = request.to_dict()
+    except ToolInvocationContractError as exc:
+        error_message = str(exc)
+        tool_id = request.tool_id if isinstance(request.tool_id, str) and request.tool_id.strip() else "invalid_tool_id"
+        request_id = request.request_id if isinstance(request.request_id, str) and request.request_id.strip() else "invalid_request_id"
+
+        tool_response = {
+            "request_id": request_id,
+            "tool_id": tool_id,
+            "status": "error",
+            "result": None,
+            "error": {
+                "error_type": "invalid_tool_invocation_request",
+                "message": error_message,
+            },
+            "correlation_id": None,
+            "can_govern_truth": False,
+        }
+        audit_sink_result = {
+            "sink_name": "request_validation",
+            "accepted": False,
+            "event_id": None,
+            "request_id": request_id,
+            "tool_id": tool_id,
+            "response_status": "error",
+            "error": {
+                "error_type": "audit_event_build_error",
+                "message": error_message,
+            },
+            "can_govern_truth": False,
+        }
+
+        return ToolExecutionOrchestrationResult(
+            request_id=request_id,
+            tool_id=tool_id,
+            response_status="error",
+            audit_sink_name="request_validation",
+            audit_accepted=False,
+            tool_response=tool_response,
+            audit_sink_result=audit_sink_result,
+            can_govern_truth=False,
+        )
+
+    return None
+def _build_and_accept_audit_event(
+    *,
+    request: ToolInvocationRequest,
+    tool_response: ToolInvocationResponse,
+    sink: ToolExecutionAuditSink,
+    event_id: str | None,
+    created_at: str | None,
+    event_source: str,
+) -> ToolExecutionAuditSinkResult:
+    try:
+        audit_event = build_tool_execution_audit_event(
+            request=request,
+            response=tool_response,
+            event_id=event_id,
+            created_at=created_at,
+            event_source=event_source,
+        )
+    except (ToolExecutionAuditContractError, ToolInvocationContractError) as exc:
+        return ToolExecutionAuditSinkResult(
+            sink_name=_sink_name(sink),
+            accepted=False,
+            event_id=None,
+            request_id=request.request_id,
+            tool_id=request.tool_id,
+            response_status=tool_response.to_dict()["status"],
+            error={
+                "error_type": "audit_event_build_error",
+                "message": str(exc),
+            },
+            can_govern_truth=False,
+        )
+
+    return sink.accept(audit_event)
+
+
+def _validate_sink(sink: object) -> None:
+    if not hasattr(sink, "accept") or not callable(getattr(sink, "accept")):
+        raise ToolExecutionOrchestratorContractError(
+            "audit_sink must implement accept(event)."
+        )
+
+
+def _sink_name(sink: object) -> str:
+    name = getattr(sink, "sink_name", sink.__class__.__name__)
+    if not isinstance(name, str) or not name.strip():
+        return "unknown_audit_sink"
+    return name.strip()
+
+
+def _require_non_empty(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ToolExecutionOrchestratorContractError(
+            f"{field_name} must be a non-empty string."
+        )
+    return value.strip()

--- a/src/tests/test_tool_execution_orchestrator_contract.py
+++ b/src/tests/test_tool_execution_orchestrator_contract.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_execution_audit_sink import (
+    InMemoryToolExecutionAuditSink,
+    ToolExecutionAuditSinkResult,
+)
+from src.application.tools.tool_execution_orchestrator import (
+    ToolExecutionOrchestrationResult,
+    ToolExecutionOrchestratorContractError,
+    execute_tool_with_audit,
+)
+from src.application.tools.tool_invocation_contract import ToolInvocationRequest
+
+
+def _request(
+    tool_id: str = CALCULATOR_TOOL_ID,
+    arguments: dict | None = None,
+    request_id: str = "req-001",
+):
+    return ToolInvocationRequest(
+        request_id=request_id,
+        tool_id=tool_id,
+        arguments=arguments or {"operation": "add", "operands": [1, 2]},
+        correlation_id="chat-001",
+        requested_by="test",
+        consent_granted=False,
+    )
+
+
+def test_successful_calculator_request_returns_execution_and_audit_result():
+    result = execute_tool_with_audit(
+        _request(),
+        event_id="evt-001",
+        created_at="2026-04-28T06:00:00Z",
+    ).to_dict()
+
+    assert result["request_id"] == "req-001"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["response_status"] == "success"
+    assert result["audit_sink_name"] == "noop_tool_execution_audit_sink"
+    assert result["audit_accepted"] is True
+    assert result["tool_response"]["result"]["computed_result"] == "3"
+    assert result["tool_response"]["can_govern_truth"] is False
+    assert result["audit_sink_result"]["accepted"] is True
+    assert result["audit_sink_result"]["can_govern_truth"] is False
+    assert result["can_govern_truth"] is False
+
+
+def test_unknown_tool_keeps_tool_error_visible_and_still_audits():
+    result = execute_tool_with_audit(
+        _request(tool_id="unknown.local", arguments={"operation": "add"}),
+        event_id="evt-unknown",
+    ).to_dict()
+
+    assert result["response_status"] == "error"
+    assert result["tool_response"]["status"] == "error"
+    assert result["tool_response"]["error"]["error_type"] == "tool_not_eligible"
+    assert result["audit_accepted"] is True
+    assert result["audit_sink_result"]["event_id"] == "evt-unknown"
+    assert result["can_govern_truth"] is False
+
+
+def test_default_sink_is_noop_and_does_not_store_events():
+    result = execute_tool_with_audit(_request()).to_dict()
+
+    assert result["audit_sink_name"] == "noop_tool_execution_audit_sink"
+    assert result["audit_accepted"] is True
+
+
+def test_injected_in_memory_sink_receives_exactly_one_event():
+    sink = InMemoryToolExecutionAuditSink()
+
+    result = execute_tool_with_audit(
+        _request(),
+        audit_sink=sink,
+        event_id="evt-001",
+    ).to_dict()
+
+    assert result["audit_sink_name"] == "in_memory_tool_execution_audit_sink"
+    assert result["audit_accepted"] is True
+    assert len(sink.events()) == 1
+    assert sink.events()[0]["event_id"] == "evt-001"
+    assert sink.events()[0]["request_id"] == "req-001"
+
+
+def test_invalid_request_object_is_rejected():
+    with pytest.raises(ToolExecutionOrchestratorContractError, match="ToolInvocationRequest"):
+        execute_tool_with_audit({"bad": True})
+
+
+def test_invalid_sink_object_is_rejected():
+    with pytest.raises(ToolExecutionOrchestratorContractError, match="accept"):
+        execute_tool_with_audit(_request(), audit_sink=object())
+
+
+def test_sink_rejection_is_visible_without_hiding_tool_response():
+    class RejectingSink:
+        sink_name = "rejecting_sink"
+
+        def accept(self, event):
+            return ToolExecutionAuditSinkResult(
+                sink_name=self.sink_name,
+                accepted=False,
+                event_id=event.event_id,
+                request_id=event.request_id,
+                tool_id=event.tool_id,
+                response_status=event.response_status,
+                error={"error_type": "sink_rejected", "message": "blocked"},
+                can_govern_truth=False,
+            )
+
+    result = execute_tool_with_audit(
+        _request(),
+        audit_sink=RejectingSink(),
+        event_id="evt-001",
+    ).to_dict()
+
+    assert result["response_status"] == "success"
+    assert result["tool_response"]["status"] == "success"
+    assert result["audit_accepted"] is False
+    assert result["audit_sink_result"]["error"]["error_type"] == "sink_rejected"
+
+
+def test_audit_event_build_error_is_visible_without_hiding_tool_response():
+    result = execute_tool_with_audit(
+        _request(),
+        event_id="   ",
+    ).to_dict()
+
+    assert result["response_status"] == "success"
+    assert result["tool_response"]["status"] == "success"
+    assert result["audit_accepted"] is False
+    assert result["audit_sink_result"]["error"]["error_type"] == "audit_event_build_error"
+    assert "event_id" in result["audit_sink_result"]["error"]["message"]
+
+
+def test_orchestration_result_is_json_serializable():
+    result = execute_tool_with_audit(_request()).to_dict()
+
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_orchestration_result_cannot_govern_truth():
+    with pytest.raises(ToolExecutionOrchestratorContractError, match="cannot govern truth"):
+        ToolExecutionOrchestrationResult(
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            audit_sink_name="sink",
+            audit_accepted=True,
+            tool_response={"status": "success"},
+            audit_sink_result={"accepted": True},
+            can_govern_truth=True,
+        ).to_dict()
+
+
+def test_orchestration_result_requires_mapping_payloads():
+    with pytest.raises(ToolExecutionOrchestratorContractError, match="tool_response"):
+        ToolExecutionOrchestrationResult(
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            audit_sink_name="sink",
+            audit_accepted=True,
+            tool_response="bad",
+            audit_sink_result={"accepted": True},
+            can_govern_truth=False,
+        ).to_dict()
+
+    with pytest.raises(ToolExecutionOrchestratorContractError, match="audit_sink_result"):
+        ToolExecutionOrchestrationResult(
+            request_id="req-001",
+            tool_id=CALCULATOR_TOOL_ID,
+            response_status="success",
+            audit_sink_name="sink",
+            audit_accepted=True,
+            tool_response={"status": "success"},
+            audit_sink_result="bad",
+            can_govern_truth=False,
+        ).to_dict()
+
+
+def test_orchestrator_does_not_write_or_persist_by_contract(tmp_path):
+    before = set(tmp_path.iterdir())
+
+    execute_tool_with_audit(_request())
+
+    after = set(tmp_path.iterdir())
+    assert after == before
+
+
+def test_orchestrator_does_not_parse_chat_or_llm_tool_calls():
+    result = execute_tool_with_audit(
+        _request(arguments={"operation": "add", "operands": [1, 2]})
+    ).to_dict()
+
+    assert "chat_message" not in result
+    assert "llm_tool_call" not in result
+    assert "router_decision" not in result
+
+def test_falsey_injected_sink_is_honored():
+    class FalseySink:
+        sink_name = "falsey_sink"
+
+        def __init__(self):
+            self.events = []
+
+        def __bool__(self):
+            return False
+
+        def accept(self, event):
+            self.events.append(event.to_dict())
+            return ToolExecutionAuditSinkResult(
+                sink_name=self.sink_name,
+                accepted=True,
+                event_id=event.event_id,
+                request_id=event.request_id,
+                tool_id=event.tool_id,
+                response_status=event.response_status,
+                error=None,
+                can_govern_truth=False,
+            )
+
+    sink = FalseySink()
+
+    result = execute_tool_with_audit(
+        _request(),
+        audit_sink=sink,
+        event_id="evt-falsey",
+    ).to_dict()
+
+    assert result["audit_sink_name"] == "falsey_sink"
+    assert result["audit_accepted"] is True
+    assert len(sink.events) == 1
+    assert sink.events[0]["event_id"] == "evt-falsey"
+
+
+def test_request_validation_error_during_audit_build_is_controlled():
+    result = execute_tool_with_audit(
+        _request(request_id="   "),
+        event_id="evt-invalid-request",
+    ).to_dict()
+
+    assert result["response_status"] == "error"
+    assert result["tool_response"]["status"] == "error"
+    assert result["audit_accepted"] is False
+    assert result["audit_sink_result"]["error"]["error_type"] == "audit_event_build_error"
+    assert "request_id" in result["audit_sink_result"]["error"]["message"]


### PR DESCRIPTION
## Summary

Adds a bounded non-chat orchestration contract for deterministic local tool execution with audit event generation and non-writing audit sink acceptance.

This PR composes existing approved contracts only:

```text
ToolInvocationRequest
-> execute_tool_invocation(...)
-> build_tool_execution_audit_event(...)
-> audit_sink.accept(...)
-> ToolExecutionOrchestrationResult
```

## Scope

Added:

- `src/application/tools/tool_execution_orchestrator.py`
- `src/tests/test_tool_execution_orchestrator_contract.py`

## What this provides

- `ToolExecutionOrchestratorContractError`
- `ToolExecutionOrchestrationResult`
- `execute_tool_with_audit(...)`
- default `NoopToolExecutionAuditSink` usage
- injectable audit sink support for tests/future integration
- controlled audit-event build error envelope
- execution response plus audit sink result in one JSON-safe result
- non-truth-governing orchestration result
- tests for success, unknown-tool error visibility, sink rejection visibility, audit-event build error visibility, invalid request rejection, invalid sink rejection, JSON serialization, no persistence behavior, and no chat/router/LLM parser fields

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_execution_harness.py src\application\tools\tool_execution_audit.py src\application\tools\tool_execution_audit_sink.py src\application\tools\tool_execution_orchestrator.py src\tests\test_tool_execution_orchestrator_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py
149 passed in 0.29s
```

BOM cleanup proof:

```text
No BOM: src\application\tools\tool_execution_orchestrator.py
No BOM: src\tests\test_tool_execution_orchestrator_contract.py
```

Diff hygiene:

```text
git diff --cached --check
# no output
```

Remote file inspection confirms both new files no longer start with a UTF-8 BOM.

## Non-scope preserved

- No chat wiring
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: controlled; orchestration-contract-only
- Product risk: reduced by proving a single governed tool execution boundary before chat integration

Related: issue #71.