### PR TITLE
Add tool orchestrator export boundary

### DIFF
--- a/src/application/tools/__init__.py
+++ b/src/application/tools/__init__.py
@@ -1,4 +1,43 @@
-﻿"""Tool registry package for bounded SerapeumAI application tools.
+"""Application tool contract exports.
 
-This package defines contracts only. It does not execute tools.
+This package boundary exposes stable application-tool contracts only.
+It does not wire chat, route autonomous tool calls, parse LLM tool calls,
+persist audits, touch storage, use internet, or interact with UI/runtime
+providers.
+
+Exports are resolved lazily so plain package import stays side-effect-light.
 """
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "ToolExecutionOrchestrationResult",
+    "ToolExecutionOrchestratorContractError",
+    "execute_tool_with_audit",
+]
+
+_ORCHESTRATOR_EXPORTS = set(__all__)
+
+
+def __getattr__(name: str) -> Any:
+    if name not in _ORCHESTRATOR_EXPORTS:
+        raise AttributeError(f"module 'src.application.tools' has no attribute {name!r}")
+
+    from src.application.tools.tool_execution_orchestrator import (
+        ToolExecutionOrchestrationResult,
+        ToolExecutionOrchestratorContractError,
+        execute_tool_with_audit,
+    )
+
+    exports = {
+        "ToolExecutionOrchestrationResult": ToolExecutionOrchestrationResult,
+        "ToolExecutionOrchestratorContractError": ToolExecutionOrchestratorContractError,
+        "execute_tool_with_audit": execute_tool_with_audit,
+    }
+    return exports[name]
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | _ORCHESTRATOR_EXPORTS)

--- a/src/tests/test_tool_execution_orchestrator_exports.py
+++ b/src/tests/test_tool_execution_orchestrator_exports.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import src.application.tools as tools
+from src.application.tools import (
+    ToolExecutionOrchestrationResult,
+    ToolExecutionOrchestratorContractError,
+    execute_tool_with_audit,
+)
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_execution_orchestrator import (
+    ToolExecutionOrchestrationResult as DirectToolExecutionOrchestrationResult,
+    ToolExecutionOrchestratorContractError as DirectToolExecutionOrchestratorContractError,
+    execute_tool_with_audit as direct_execute_tool_with_audit,
+)
+from src.application.tools.tool_invocation_contract import ToolInvocationRequest
+
+
+def _request():
+    return ToolInvocationRequest(
+        request_id="req-export-001",
+        tool_id=CALCULATOR_TOOL_ID,
+        arguments={"operation": "add", "operands": [1, 2]},
+        correlation_id="chat-export-001",
+        requested_by="test",
+        consent_granted=False,
+    )
+
+
+def test_package_boundary_exports_stable_orchestrator_symbols():
+    assert execute_tool_with_audit is direct_execute_tool_with_audit
+    assert ToolExecutionOrchestrationResult is DirectToolExecutionOrchestrationResult
+    assert (
+        ToolExecutionOrchestratorContractError
+        is DirectToolExecutionOrchestratorContractError
+    )
+
+
+def test_package_boundary_all_is_explicit_and_minimal():
+    assert tools.__all__ == [
+        "ToolExecutionOrchestrationResult",
+        "ToolExecutionOrchestratorContractError",
+        "execute_tool_with_audit",
+    ]
+
+
+def test_execute_tool_with_audit_works_through_package_import_path():
+    result = execute_tool_with_audit(_request(), event_id="evt-export-001").to_dict()
+
+    assert result["request_id"] == "req-export-001"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["response_status"] == "success"
+    assert result["audit_accepted"] is True
+    assert result["tool_response"]["result"]["computed_result"] == "3"
+    assert result["can_govern_truth"] is False
+    assert result["tool_response"]["can_govern_truth"] is False
+    assert result["audit_sink_result"]["can_govern_truth"] is False
+
+
+def test_private_orchestrator_helpers_are_not_exported():
+    private_names = {
+        "_validate_request_for_orchestration",
+        "_build_and_accept_audit_event",
+        "_validate_sink",
+        "_sink_name",
+        "_require_non_empty",
+    }
+
+    for name in private_names:
+        assert not hasattr(tools, name)
+
+
+def test_export_boundary_does_not_introduce_chat_router_or_llm_parser_symbols():
+    forbidden_names = {
+        "chat",
+        "chat_page",
+        "tool_router",
+        "autonomous_tool_router",
+        "llm_tool_call",
+        "parse_llm_tool_call",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+    }
+
+    for name in forbidden_names:
+        assert not hasattr(tools, name)
+
+def test_plain_package_import_does_not_mutate_decimal_precision():
+    import decimal
+    import importlib
+    import sys
+
+    sys.modules.pop("src.application.tools", None)
+
+    original_precision = decimal.getcontext().prec
+    decimal.getcontext().prec = 7
+    try:
+        imported_tools = importlib.import_module("src.application.tools")
+
+        assert imported_tools.__all__ == [
+            "ToolExecutionOrchestrationResult",
+            "ToolExecutionOrchestratorContractError",
+            "execute_tool_with_audit",
+        ]
+        assert decimal.getcontext().prec == 7
+    finally:
+        decimal.getcontext().prec = original_precision


### PR DESCRIPTION
## Summary

Adds a narrow `src.application.tools` export boundary for the already-merged non-chat tool execution audit orchestrator contract.

This PR does not change orchestrator behavior. It only exposes stable import symbols for later bounded integration packets.

## Scope

Added/updated:

- `src/application/tools/__init__.py`
- `src/tests/test_tool_execution_orchestrator_exports.py`

## Public exports

```text
ToolExecutionOrchestrationResult
ToolExecutionOrchestratorContractError
execute_tool_with_audit
```

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\__init__.py src\application\tools\tool_execution_orchestrator.py src\tests\test_tool_execution_orchestrator_exports.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py
156 passed in 0.30s
```

BOM proof:

```text
No BOM: src\application\tools\__init__.py
No BOM: src\tests\test_tool_execution_orchestrator_exports.py
```

Diff hygiene:

```text
git diff --cached --check
# no output
```

Remote file inspection confirms both files no longer start with a UTF-8 BOM.

## Non-scope preserved

- No behavior changes in orchestrator
- No chat wiring
- No chat-page imports
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; export-boundary-only
- Product risk: low; does not enable chat/tool use yet

Related: issue #73.