### PR TITLE
Add chat tool request adapter contract

### DIFF
--- a/src/application/tools/tool_request_adapter.py
+++ b/src/application/tools/tool_request_adapter.py
@@ -1,0 +1,162 @@
+"""Structured adapter for future chat-owned tool requests.
+
+This module adapts application-owned structured request mappings into the
+ToolInvocationRequest contract. It does not parse natural language, execute
+tools, route autonomously, persist audits, touch storage, import chat UI, or
+call the tool execution orchestrator.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.application.tools.tool_invocation_contract import (
+    ToolInvocationContractError,
+    ToolInvocationRequest,
+)
+
+
+class ToolRequestAdapterContractError(ValueError):
+    """Raised when the adapter result contract itself is invalid."""
+
+
+_ALLOWED_STATUSES = {"ready", "refusal", "clarification", "error"}
+
+
+@dataclass(frozen=True)
+class ToolRequestAdapterResult:
+    status: str
+    tool_request: Mapping[str, Any] | None = None
+    error: Mapping[str, Any] | None = None
+    clarification: Mapping[str, Any] | None = None
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        if self.status not in _ALLOWED_STATUSES:
+            raise ToolRequestAdapterContractError("status must be one of ready/refusal/clarification/error.")
+        if self.can_govern_truth is not False:
+            raise ToolRequestAdapterContractError("adapter result cannot govern truth.")
+        if self.tool_request is not None and not isinstance(self.tool_request, Mapping):
+            raise ToolRequestAdapterContractError("tool_request must be a mapping or None.")
+        if self.error is not None and not isinstance(self.error, Mapping):
+            raise ToolRequestAdapterContractError("error must be a mapping or None.")
+        if self.clarification is not None and not isinstance(self.clarification, Mapping):
+            raise ToolRequestAdapterContractError("clarification must be a mapping or None.")
+        if self.status == "ready" and self.tool_request is None:
+            raise ToolRequestAdapterContractError("ready result requires tool_request.")
+        if self.status in {"refusal", "error"} and self.error is None:
+            raise ToolRequestAdapterContractError("refusal/error result requires error.")
+        if self.status == "clarification" and self.clarification is None:
+            raise ToolRequestAdapterContractError("clarification result requires clarification.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "status": self.status,
+            "tool_request": dict(self.tool_request) if self.tool_request is not None else None,
+            "error": dict(self.error) if self.error is not None else None,
+            "clarification": dict(self.clarification) if self.clarification is not None else None,
+            "can_govern_truth": False,
+        }
+
+
+def adapt_tool_request(payload: Mapping[str, Any]) -> ToolRequestAdapterResult:
+    if not isinstance(payload, Mapping):
+        return _error(
+            "invalid_payload",
+            "Tool request payload must be a mapping.",
+        )
+
+    request_id = _string_or_default(payload.get("request_id"), "adapted-tool-request")
+    tool_id = _string_or_none(payload.get("tool_id"))
+    arguments = payload.get("arguments")
+    correlation_id = _string_or_none(payload.get("correlation_id"))
+    requested_by = _string_or_default(payload.get("requested_by"), "tool_request_adapter")
+    consent_granted = payload.get("consent_granted", False)
+    if not isinstance(consent_granted, bool):
+        return _error(
+            "invalid_consent_granted",
+            "Tool request consent_granted must be a boolean when provided.",
+        )
+
+    if tool_id is None:
+        return _clarification(
+            missing_field="tool_id",
+            message="Tool request is missing a tool_id.",
+        )
+
+    if "arguments" not in payload:
+        return _clarification(
+            missing_field="arguments",
+            message="Tool request is missing arguments.",
+        )
+
+    if not isinstance(arguments, Mapping):
+        return _error(
+            "invalid_arguments",
+            "Tool request arguments must be a mapping.",
+        )
+
+    try:
+        request = ToolInvocationRequest(
+            request_id=request_id,
+            tool_id=tool_id,
+            arguments=dict(arguments),
+            correlation_id=correlation_id,
+            requested_by=requested_by,
+            consent_granted=consent_granted,
+        )
+        request_dict = request.to_dict()
+    except ToolInvocationContractError as exc:
+        return _error(
+            "invalid_tool_invocation_request",
+            str(exc),
+        )
+
+    return ToolRequestAdapterResult(
+        status="ready",
+        tool_request=request_dict,
+        error=None,
+        clarification=None,
+        can_govern_truth=False,
+    )
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _string_or_default(value: Any, default: str) -> str:
+    stripped = _string_or_none(value)
+    return stripped if stripped is not None else default
+
+
+def _clarification(*, missing_field: str, message: str) -> ToolRequestAdapterResult:
+    return ToolRequestAdapterResult(
+        status="clarification",
+        tool_request=None,
+        error=None,
+        clarification={
+            "reason": "missing_required_field",
+            "missing_field": missing_field,
+            "message": message,
+        },
+        can_govern_truth=False,
+    )
+
+
+def _error(error_type: str, message: str) -> ToolRequestAdapterResult:
+    return ToolRequestAdapterResult(
+        status="error",
+        tool_request=None,
+        error={
+            "error_type": error_type,
+            "message": message,
+        },
+        clarification=None,
+        can_govern_truth=False,
+    )

--- a/src/tests/test_tool_request_adapter_contract.py
+++ b/src/tests/test_tool_request_adapter_contract.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_invocation_contract import ToolInvocationRequest
+from src.application.tools.tool_request_adapter import (
+    ToolRequestAdapterResult,
+    adapt_tool_request,
+)
+
+
+def _valid_payload():
+    return {
+        "request_id": "req-adapter-001",
+        "tool_id": CALCULATOR_TOOL_ID,
+        "arguments": {"operation": "add", "operands": [1, 2]},
+        "correlation_id": "chat-adapter-001",
+        "requested_by": "chat_adapter",
+        "consent_granted": False,
+    }
+
+
+def test_valid_structured_mapping_becomes_ready_request_envelope():
+    result = adapt_tool_request(_valid_payload()).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["error"] is None
+    assert result["clarification"] is None
+    assert result["can_govern_truth"] is False
+
+    request = ToolInvocationRequest(**result["tool_request"])
+    assert request.to_dict()["request_id"] == "req-adapter-001"
+    assert request.to_dict()["tool_id"] == CALCULATOR_TOOL_ID
+    assert request.to_dict()["arguments"] == {"operation": "add", "operands": [1, 2]}
+    assert request.to_dict()["correlation_id"] == "chat-adapter-001"
+    assert request.to_dict()["requested_by"] == "chat_adapter"
+    assert request.to_dict()["consent_granted"] is False
+
+
+def test_missing_tool_id_returns_controlled_clarification():
+    payload = _valid_payload()
+    payload.pop("tool_id")
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "clarification"
+    assert result["tool_request"] is None
+    assert result["clarification"]["missing_field"] == "tool_id"
+    assert result["can_govern_truth"] is False
+
+
+def test_missing_arguments_returns_controlled_clarification():
+    payload = _valid_payload()
+    payload.pop("arguments")
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "clarification"
+    assert result["tool_request"] is None
+    assert result["clarification"]["missing_field"] == "arguments"
+    assert result["can_govern_truth"] is False
+
+
+def test_non_mapping_arguments_returns_controlled_error():
+    payload = _valid_payload()
+    payload["arguments"] = ["not", "a", "mapping"]
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "error"
+    assert result["tool_request"] is None
+    assert result["error"]["error_type"] == "invalid_arguments"
+    assert result["can_govern_truth"] is False
+
+
+def test_non_mapping_payload_returns_controlled_error():
+    result = adapt_tool_request(["bad"]).to_dict()
+
+    assert result["status"] == "error"
+    assert result["tool_request"] is None
+    assert result["error"]["error_type"] == "invalid_payload"
+    assert result["can_govern_truth"] is False
+
+
+def test_blank_request_id_is_repaired_deterministically():
+    payload = _valid_payload()
+    payload["request_id"] = "   "
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["tool_request"]["request_id"] == "adapted-tool-request"
+    assert result["can_govern_truth"] is False
+
+
+def test_unknown_tool_id_remains_structurally_ready_for_orchestrator_rejection():
+    payload = _valid_payload()
+    payload["tool_id"] = "unknown.local"
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["tool_request"]["tool_id"] == "unknown.local"
+    assert result["can_govern_truth"] is False
+
+
+def test_result_is_json_serializable():
+    result = adapt_tool_request(_valid_payload()).to_dict()
+
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_adapter_result_contract_cannot_govern_truth():
+    result = ToolRequestAdapterResult(
+        status="ready",
+        tool_request={"request_id": "req", "tool_id": CALCULATOR_TOOL_ID, "arguments": {}},
+        can_govern_truth=True,
+    )
+
+    try:
+        result.to_dict()
+    except Exception as exc:
+        assert "cannot govern truth" in str(exc)
+    else:
+        raise AssertionError("Expected adapter result to reject governing truth.")
+
+
+def test_adapter_does_not_execute_tools_or_return_tool_result():
+    result = adapt_tool_request(_valid_payload()).to_dict()
+
+    assert result["status"] == "ready"
+    assert "tool_response" not in result
+    assert "audit_sink_result" not in result
+    assert "computed_result" not in result["tool_request"]
+    assert result["tool_request"]["arguments"]["operation"] == "add"
+
+
+def test_adapter_does_not_expose_chat_router_or_llm_parser_symbols():
+    import src.application.tools.tool_request_adapter as adapter
+
+    forbidden_names = {
+        "execute_tool_with_audit",
+        "tool_router",
+        "autonomous_tool_router",
+        "parse_llm_tool_call",
+        "llm_tool_call",
+        "chat_page",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+    }
+
+    for name in forbidden_names:
+        assert not hasattr(adapter, name)
+
+def test_non_boolean_string_consent_returns_controlled_error():
+    payload = _valid_payload()
+    payload["consent_granted"] = "false"
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "error"
+    assert result["tool_request"] is None
+    assert result["error"]["error_type"] == "invalid_consent_granted"
+    assert result["can_govern_truth"] is False
+
+
+def test_non_boolean_numeric_consent_returns_controlled_error():
+    payload = _valid_payload()
+    payload["consent_granted"] = 1
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "error"
+    assert result["tool_request"] is None
+    assert result["error"]["error_type"] == "invalid_consent_granted"
+    assert result["can_govern_truth"] is False
+
+
+def test_omitted_consent_defaults_to_false_without_coercing_truthy_values():
+    payload = _valid_payload()
+    payload.pop("consent_granted")
+
+    result = adapt_tool_request(payload).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["tool_request"]["consent_granted"] is False
+    assert result["can_govern_truth"] is False


### PR DESCRIPTION
## Summary

Adds a structured, non-executing request adapter for future chat-owned tool requests.

This PR does not wire chat to tools. It only adapts an application-owned structured mapping into the existing `ToolInvocationRequest` contract, or returns controlled clarification/error envelopes when required fields are missing or invalid.

## Scope

Added:

- `src/application/tools/tool_request_adapter.py`
- `src/tests/test_tool_request_adapter_contract.py`

## Contract symbols

```text
ToolRequestAdapterContractError
ToolRequestAdapterResult
adapt_tool_request
```

## Behavior

- Valid structured mapping returns `status == "ready"`.
- Ready result contains a `ToolInvocationRequest`-compatible mapping.
- Missing `tool_id` returns controlled clarification.
- Missing `arguments` returns controlled clarification.
- Non-mapping payload or arguments return controlled errors.
- Blank `request_id` is repaired deterministically.
- Unknown `tool_id` remains structurally ready for later orchestrator rejection.
- Adapter result is JSON-serializable and non-truth-governing.
- Adapter does not execute tools or return tool results.

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_request_adapter.py src\application\tools\tool_invocation_contract.py src\tests\test_tool_request_adapter_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py
168 passed in 0.40s
```

BOM proof:

```text
No BOM: src\application\tools\tool_request_adapter.py
No BOM: src\tests\test_tool_request_adapter_contract.py
```

Diff hygiene:

```text
git diff --check
# no output
git diff --cached --check
# no output
```

Remote file inspection confirms both files no longer start with a UTF-8 BOM.

## Non-scope preserved

- No tool execution
- No call to `execute_tool_with_audit(...)`
- No chat wiring
- No chat-page imports
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No behavior changes in orchestrator
- No packaging changes
- No dependency changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium only if widened later into chat routing or LLM parsing; this PR does neither
- Product risk: low; structured-request-only and non-truth-governing

Related: issue #75.