### PR TITLE
Add tool request adapter export boundary

### DIFF
--- a/src/application/tools/__init__.py
+++ b/src/application/tools/__init__.py
@@ -12,32 +12,52 @@ from __future__ import annotations
 
 from typing import Any
 
-__all__ = [
+_ORCHESTRATOR_EXPORTS = {
     "ToolExecutionOrchestrationResult",
     "ToolExecutionOrchestratorContractError",
     "execute_tool_with_audit",
-]
+}
 
-_ORCHESTRATOR_EXPORTS = set(__all__)
+_ADAPTER_EXPORTS = {
+    "ToolRequestAdapterContractError",
+    "ToolRequestAdapterResult",
+    "adapt_tool_request",
+}
+
+__all__ = sorted(_ORCHESTRATOR_EXPORTS | _ADAPTER_EXPORTS)
 
 
 def __getattr__(name: str) -> Any:
-    if name not in _ORCHESTRATOR_EXPORTS:
-        raise AttributeError(f"module 'src.application.tools' has no attribute {name!r}")
+    if name in _ORCHESTRATOR_EXPORTS:
+        from src.application.tools.tool_execution_orchestrator import (
+            ToolExecutionOrchestrationResult,
+            ToolExecutionOrchestratorContractError,
+            execute_tool_with_audit,
+        )
 
-    from src.application.tools.tool_execution_orchestrator import (
-        ToolExecutionOrchestrationResult,
-        ToolExecutionOrchestratorContractError,
-        execute_tool_with_audit,
-    )
+        exports = {
+            "ToolExecutionOrchestrationResult": ToolExecutionOrchestrationResult,
+            "ToolExecutionOrchestratorContractError": ToolExecutionOrchestratorContractError,
+            "execute_tool_with_audit": execute_tool_with_audit,
+        }
+        return exports[name]
 
-    exports = {
-        "ToolExecutionOrchestrationResult": ToolExecutionOrchestrationResult,
-        "ToolExecutionOrchestratorContractError": ToolExecutionOrchestratorContractError,
-        "execute_tool_with_audit": execute_tool_with_audit,
-    }
-    return exports[name]
+    if name in _ADAPTER_EXPORTS:
+        from src.application.tools.tool_request_adapter import (
+            ToolRequestAdapterContractError,
+            ToolRequestAdapterResult,
+            adapt_tool_request,
+        )
+
+        exports = {
+            "ToolRequestAdapterContractError": ToolRequestAdapterContractError,
+            "ToolRequestAdapterResult": ToolRequestAdapterResult,
+            "adapt_tool_request": adapt_tool_request,
+        }
+        return exports[name]
+
+    raise AttributeError(f"module 'src.application.tools' has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:
-    return sorted(set(globals()) | _ORCHESTRATOR_EXPORTS)
+    return sorted(set(globals()) | set(__all__))

--- a/src/tests/test_tool_execution_orchestrator_exports.py
+++ b/src/tests/test_tool_execution_orchestrator_exports.py
@@ -36,11 +36,16 @@ def test_package_boundary_exports_stable_orchestrator_symbols():
 
 
 def test_package_boundary_all_is_explicit_and_minimal():
-    assert tools.__all__ == [
+    assert tools.__all__ == sorted(
+        [
         "ToolExecutionOrchestrationResult",
         "ToolExecutionOrchestratorContractError",
+        "ToolRequestAdapterContractError",
+        "ToolRequestAdapterResult",
+        "adapt_tool_request",
         "execute_tool_with_audit",
     ]
+    )
 
 
 def test_execute_tool_with_audit_works_through_package_import_path():
@@ -97,11 +102,16 @@ def test_plain_package_import_does_not_mutate_decimal_precision():
     try:
         imported_tools = importlib.import_module("src.application.tools")
 
-        assert imported_tools.__all__ == [
-            "ToolExecutionOrchestrationResult",
-            "ToolExecutionOrchestratorContractError",
-            "execute_tool_with_audit",
-        ]
+        assert imported_tools.__all__ == sorted(
+            [
+        "ToolExecutionOrchestrationResult",
+        "ToolExecutionOrchestratorContractError",
+        "ToolRequestAdapterContractError",
+        "ToolRequestAdapterResult",
+        "adapt_tool_request",
+        "execute_tool_with_audit",
+    ]
+        )
         assert decimal.getcontext().prec == 7
     finally:
         decimal.getcontext().prec = original_precision

--- a/src/tests/test_tool_request_adapter_exports.py
+++ b/src/tests/test_tool_request_adapter_exports.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import decimal
+import importlib
+import json
+import sys
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+
+
+def _purge_tool_package_and_lazy_targets() -> None:
+    for module_name in [
+        "src.application.tools",
+        "src.application.tools.tool_request_adapter",
+        "src.application.tools.tool_execution_orchestrator",
+    ]:
+        sys.modules.pop(module_name, None)
+
+
+def test_plain_package_import_does_not_eagerly_load_adapter_or_orchestrator():
+    _purge_tool_package_and_lazy_targets()
+
+    imported_tools = importlib.import_module("src.application.tools")
+
+    assert imported_tools.__all__ == sorted(
+        [
+            "ToolExecutionOrchestrationResult",
+            "ToolExecutionOrchestratorContractError",
+            "execute_tool_with_audit",
+            "ToolRequestAdapterContractError",
+            "ToolRequestAdapterResult",
+            "adapt_tool_request",
+        ]
+    )
+    assert "src.application.tools.tool_request_adapter" not in sys.modules
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+
+
+def test_plain_package_import_does_not_mutate_decimal_precision():
+    _purge_tool_package_and_lazy_targets()
+
+    original_precision = decimal.getcontext().prec
+    decimal.getcontext().prec = 9
+    try:
+        importlib.import_module("src.application.tools")
+        assert decimal.getcontext().prec == 9
+    finally:
+        decimal.getcontext().prec = original_precision
+
+
+def test_adapter_public_symbols_import_through_package_boundary():
+    from src.application.tools import (
+        ToolRequestAdapterContractError,
+        ToolRequestAdapterResult,
+        adapt_tool_request,
+    )
+    from src.application.tools.tool_request_adapter import (
+        ToolRequestAdapterContractError as DirectError,
+        ToolRequestAdapterResult as DirectResult,
+        adapt_tool_request as direct_adapt,
+    )
+
+    assert ToolRequestAdapterContractError is DirectError
+    assert ToolRequestAdapterResult is DirectResult
+    assert adapt_tool_request is direct_adapt
+
+
+def test_adapter_import_through_package_boundary_works_and_cannot_govern_truth():
+    from src.application.tools import adapt_tool_request
+
+    result = adapt_tool_request(
+        {
+            "request_id": "req-export-001",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "arguments": {"operation": "add", "operands": [1, 2]},
+            "correlation_id": "chat-export-001",
+            "requested_by": "export_test",
+            "consent_granted": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["tool_request"]["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["can_govern_truth"] is False
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_existing_orchestrator_exports_remain_available():
+    from src.application.tools import (
+        ToolExecutionOrchestrationResult,
+        ToolExecutionOrchestratorContractError,
+        execute_tool_with_audit,
+    )
+    from src.application.tools.tool_execution_orchestrator import (
+        ToolExecutionOrchestrationResult as DirectResult,
+        ToolExecutionOrchestratorContractError as DirectError,
+        execute_tool_with_audit as direct_execute,
+    )
+
+    assert ToolExecutionOrchestrationResult is DirectResult
+    assert ToolExecutionOrchestratorContractError is DirectError
+    assert execute_tool_with_audit is direct_execute
+
+
+def test_private_adapter_helpers_are_not_exported():
+    import src.application.tools as tools
+
+    forbidden_names = {
+        "_string_or_none",
+        "_string_or_default",
+        "_clarification",
+        "_error",
+    }
+
+    for name in forbidden_names:
+        assert name not in tools.__all__
+        try:
+            getattr(tools, name)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError(f"Private helper was exported: {name}")
+
+
+def test_no_chat_router_or_llm_parser_symbols_are_exported():
+    import src.application.tools as tools
+
+    forbidden_names = {
+        "chat_page",
+        "chat_panel",
+        "tool_router",
+        "autonomous_tool_router",
+        "parse_llm_tool_call",
+        "llm_tool_call",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+    }
+
+    for name in forbidden_names:
+        assert name not in tools.__all__
+        try:
+            getattr(tools, name)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError(f"Forbidden symbol was exported: {name}")


### PR DESCRIPTION
## Summary

Adds lazy package exports for the structured tool request adapter contract through `src.application.tools`.

This PR preserves the existing lazy orchestrator export boundary and extends it to include adapter symbols without eager imports.

## Scope

Updated/added:

- `src/application/tools/__init__.py`
- `src/tests/test_tool_execution_orchestrator_exports.py`
- `src/tests/test_tool_request_adapter_exports.py`

## Public exports

```text
ToolExecutionOrchestrationResult
ToolExecutionOrchestratorContractError
ToolRequestAdapterContractError
ToolRequestAdapterResult
adapt_tool_request
execute_tool_with_audit
```

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\__init__.py src\application\tools\tool_request_adapter.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_exports.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py
178 passed in 0.37s
```

Diff hygiene:

```text
git diff --cached --check
# no output
```

Remote branch inspection confirms lazy export implementation and lazy-import regression coverage.

## Non-scope preserved

- No tool execution
- No chat wiring
- No chat-page imports
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new tool behavior
- No dependency changes
- No packaging changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium only if lazy import boundary is later weakened
- Product risk: low; export-only packet does not enable chat/tool execution

Related: issue #77.