### PR TITLE
Add tool use presentation contract

### DIFF
--- a/src/application/tools/tool_use_presentation.py
+++ b/src/application/tools/tool_use_presentation.py
@@ -1,0 +1,284 @@
+"""Presentation envelopes for tool-use outcomes.
+
+This module converts adapter/orchestration outcomes into stable application
+presentation envelopes. It does not execute tools, call the orchestrator, parse
+LLM tool calls, import chat UI, persist audits, touch storage, or govern truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class ToolUsePresentationContractError(ValueError):
+    """Raised when a presentation envelope violates the contract."""
+
+
+_ALLOWED_STATUSES = {"ready", "clarification", "refusal", "error", "success"}
+_ALLOWED_SEVERITIES = {"info", "warning", "error"}
+
+
+@dataclass(frozen=True)
+class ToolUsePresentation:
+    status: str
+    severity: str
+    summary: str
+    detail: str
+    source_status: str
+    next_action: str | None = None
+    tool_id: str | None = None
+    request_id: str | None = None
+    correlation_id: str | None = None
+    metadata: Mapping[str, Any] | None = None
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        if self.status not in _ALLOWED_STATUSES:
+            raise ToolUsePresentationContractError("status is not an approved presentation status.")
+        if self.severity not in _ALLOWED_SEVERITIES:
+            raise ToolUsePresentationContractError("severity is not an approved presentation severity.")
+        if not isinstance(self.summary, str) or not self.summary.strip():
+            raise ToolUsePresentationContractError("summary must be a non-empty string.")
+        if not isinstance(self.detail, str):
+            raise ToolUsePresentationContractError("detail must be a string.")
+        if not isinstance(self.source_status, str) or not self.source_status.strip():
+            raise ToolUsePresentationContractError("source_status must be a non-empty string.")
+        if self.next_action is not None and not isinstance(self.next_action, str):
+            raise ToolUsePresentationContractError("next_action must be a string or None.")
+        if self.tool_id is not None and not isinstance(self.tool_id, str):
+            raise ToolUsePresentationContractError("tool_id must be a string or None.")
+        if self.request_id is not None and not isinstance(self.request_id, str):
+            raise ToolUsePresentationContractError("request_id must be a string or None.")
+        if self.correlation_id is not None and not isinstance(self.correlation_id, str):
+            raise ToolUsePresentationContractError("correlation_id must be a string or None.")
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise ToolUsePresentationContractError("metadata must be a mapping or None.")
+        if self.can_govern_truth is not False:
+            raise ToolUsePresentationContractError("tool-use presentation cannot govern truth.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "status": self.status,
+            "severity": self.severity,
+            "summary": self.summary,
+            "detail": self.detail,
+            "next_action": self.next_action,
+            "tool_id": self.tool_id,
+            "request_id": self.request_id,
+            "correlation_id": self.correlation_id,
+            "source_status": self.source_status,
+            "can_govern_truth": False,
+            "metadata": dict(self.metadata) if self.metadata is not None else {},
+        }
+
+
+def present_tool_adapter_result(result: Any) -> ToolUsePresentation:
+    data = _as_mapping(result)
+    if data is None:
+        return _invalid_input("adapter", "Adapter result must be a mapping or expose to_dict().")
+
+    source_status = _string_or_default(data.get("status"), "error")
+    tool_request = _mapping_or_none(data.get("tool_request"))
+    error = _mapping_or_none(data.get("error"))
+    clarification = _mapping_or_none(data.get("clarification"))
+
+    tool_id = _string_or_none(_from_mapping(tool_request, "tool_id"))
+    request_id = _string_or_none(_from_mapping(tool_request, "request_id"))
+    correlation_id = _string_or_none(_from_mapping(tool_request, "correlation_id"))
+
+    if source_status == "ready":
+        return ToolUsePresentation(
+            status="ready",
+            severity="info",
+            summary="Structured tool request is ready.",
+            detail="A validated structured tool request is ready for a later execution boundary.",
+            next_action=None,
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=source_status,
+            metadata={"source": "adapter"},
+            can_govern_truth=False,
+        )
+
+    if source_status == "clarification":
+        missing_field = _string_or_none(_from_mapping(clarification, "missing_field"))
+        message = _string_or_default(_from_mapping(clarification, "message"), "More information is required.")
+        return ToolUsePresentation(
+            status="clarification",
+            severity="warning",
+            summary="Tool request needs clarification.",
+            detail=message,
+            next_action=f"Provide the missing field: {missing_field}." if missing_field else "Provide the missing tool request information.",
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=source_status,
+            metadata={"source": "adapter", "missing_field": missing_field},
+            can_govern_truth=False,
+        )
+
+    if source_status == "refusal":
+        reason = _string_or_default(_from_mapping(error, "error_type"), "tool_request_refused")
+        message = _string_or_default(_from_mapping(error, "message"), "The tool request was refused.")
+        return ToolUsePresentation(
+            status="refusal",
+            severity="warning",
+            summary="Tool request was refused.",
+            detail=message,
+            next_action="Revise the structured request before trying again.",
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=source_status,
+            metadata={"source": "adapter", "reason": reason},
+            can_govern_truth=False,
+        )
+
+    if source_status == "error":
+        reason = _string_or_default(_from_mapping(error, "error_type"), "tool_request_error")
+        message = _string_or_default(_from_mapping(error, "message"), "The tool request could not be prepared.")
+        return ToolUsePresentation(
+            status="error",
+            severity="error",
+            summary="Tool request could not be prepared.",
+            detail=message,
+            next_action="Correct the structured tool request.",
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=source_status,
+            metadata={"source": "adapter", "error_type": reason},
+            can_govern_truth=False,
+        )
+
+    return ToolUsePresentation(
+        status="error",
+        severity="error",
+        summary="Unsupported adapter result status.",
+        detail=f"Unsupported adapter status: {source_status}",
+        next_action="Use a supported adapter status.",
+        tool_id=tool_id,
+        request_id=request_id,
+        correlation_id=correlation_id,
+        source_status=source_status,
+        metadata={"source": "adapter"},
+        can_govern_truth=False,
+    )
+
+
+def present_tool_orchestration_result(result: Any) -> ToolUsePresentation:
+    data = _as_mapping(result)
+    if data is None:
+        return _invalid_input("orchestrator", "Orchestration result must be a mapping or expose to_dict().")
+
+    response_status = _string_or_default(data.get("response_status"), _string_or_default(data.get("status"), "error"))
+    tool_response = _mapping_or_none(data.get("tool_response"))
+    error = _mapping_or_none(data.get("error"))
+    audit_sink_result = _mapping_or_none(data.get("audit_sink_result"))
+
+    tool_id = _string_or_none(data.get("tool_id"))
+    request_id = _string_or_none(data.get("request_id"))
+    correlation_id = _string_or_none(data.get("correlation_id"))
+
+    if response_status == "success":
+        return ToolUsePresentation(
+            status="success",
+            severity="info",
+            summary="Tool completed successfully.",
+            detail="The deterministic tool completed and produced a non-truth-governing application result.",
+            next_action=None,
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=response_status,
+            metadata={
+                "source": "orchestrator",
+                "audit_accepted": bool(data.get("audit_accepted", False)),
+                "tool_response_status": _from_mapping(tool_response, "status"),
+                "audit_sink_status": _from_mapping(audit_sink_result, "status"),
+            },
+            can_govern_truth=False,
+        )
+
+    if response_status in {"blocked", "refused", "not_eligible"}:
+        message = _string_or_default(_from_mapping(error, "message"), "The tool request was refused by policy.")
+        return ToolUsePresentation(
+            status="refusal",
+            severity="warning",
+            summary="Tool request was refused.",
+            detail=message,
+            next_action="Review tool eligibility, scope, consent, and required inputs.",
+            tool_id=tool_id,
+            request_id=request_id,
+            correlation_id=correlation_id,
+            source_status=response_status,
+            metadata={"source": "orchestrator", "reason": _from_mapping(error, "error_type")},
+            can_govern_truth=False,
+        )
+
+    message = _string_or_default(_from_mapping(error, "message"), "The tool request failed before a trusted result could be presented.")
+    return ToolUsePresentation(
+        status="error",
+        severity="error",
+        summary="Tool request failed.",
+        detail=message,
+        next_action="Inspect the structured tool request and retry if appropriate.",
+        tool_id=tool_id,
+        request_id=request_id,
+        correlation_id=correlation_id,
+        source_status=response_status,
+        metadata={"source": "orchestrator", "error_type": _from_mapping(error, "error_type")},
+        can_govern_truth=False,
+    )
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    to_dict = getattr(value, "to_dict", None)
+    if callable(to_dict):
+        converted = to_dict()
+        if isinstance(converted, Mapping):
+            return converted
+    return None
+
+
+def _mapping_or_none(value: Any) -> Mapping[str, Any] | None:
+    return value if isinstance(value, Mapping) else None
+
+
+def _from_mapping(mapping: Mapping[str, Any] | None, key: str) -> Any:
+    if mapping is None:
+        return None
+    return mapping.get(key)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _string_or_default(value: Any, default: str) -> str:
+    stripped = _string_or_none(value)
+    return stripped if stripped is not None else default
+
+
+def _invalid_input(source: str, message: str) -> ToolUsePresentation:
+    return ToolUsePresentation(
+        status="error",
+        severity="error",
+        summary="Invalid tool-use presentation input.",
+        detail=message,
+        next_action="Provide a mapping or result object with to_dict().",
+        tool_id=None,
+        request_id=None,
+        correlation_id=None,
+        source_status="invalid_input",
+        metadata={"source": source, "error_type": "invalid_input"},
+        can_govern_truth=False,
+    )

--- a/src/tests/test_tool_use_presentation_contract.py
+++ b/src/tests/test_tool_use_presentation_contract.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.tool_request_adapter import adapt_tool_request
+from src.application.tools.tool_use_presentation import (
+    ToolUsePresentation,
+    present_tool_adapter_result,
+    present_tool_orchestration_result,
+)
+
+
+def _ready_adapter_result():
+    return adapt_tool_request(
+        {
+            "request_id": "req-present-001",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "arguments": {"operation": "add", "operands": [1, 2]},
+            "correlation_id": "chat-present-001",
+            "requested_by": "presentation_test",
+            "consent_granted": False,
+        }
+    )
+
+
+def test_adapter_ready_presents_non_truth_governing_ready_envelope():
+    result = present_tool_adapter_result(_ready_adapter_result()).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["severity"] == "info"
+    assert result["summary"] == "Structured tool request is ready."
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["request_id"] == "req-present-001"
+    assert result["correlation_id"] == "chat-present-001"
+    assert result["source_status"] == "ready"
+    assert result["can_govern_truth"] is False
+    assert result["metadata"]["source"] == "adapter"
+
+
+def test_adapter_clarification_presents_warning_with_next_action():
+    adapter_result = adapt_tool_request({"request_id": "req-missing-tool", "arguments": {}})
+    result = present_tool_adapter_result(adapter_result).to_dict()
+
+    assert result["status"] == "clarification"
+    assert result["severity"] == "warning"
+    assert result["source_status"] == "clarification"
+    assert result["metadata"]["missing_field"] == "tool_id"
+    assert "tool_id" in result["next_action"]
+    assert result["can_govern_truth"] is False
+
+
+def test_adapter_error_presents_controlled_error():
+    adapter_result = adapt_tool_request(
+        {
+            "request_id": "req-bad-args",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "arguments": ["bad"],
+            "consent_granted": False,
+        }
+    )
+    result = present_tool_adapter_result(adapter_result).to_dict()
+
+    assert result["status"] == "error"
+    assert result["severity"] == "error"
+    assert result["source_status"] == "error"
+    assert result["metadata"]["error_type"] == "invalid_arguments"
+    assert result["can_govern_truth"] is False
+
+
+def test_adapter_refusal_like_mapping_is_supported():
+    result = present_tool_adapter_result(
+        {
+            "status": "refusal",
+            "tool_request": {
+                "request_id": "req-refused",
+                "tool_id": CALCULATOR_TOOL_ID,
+                "correlation_id": "chat-refused",
+            },
+            "error": {
+                "error_type": "missing_consent",
+                "message": "Consent is required before this tool can run.",
+            },
+            "can_govern_truth": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "refusal"
+    assert result["severity"] == "warning"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["metadata"]["reason"] == "missing_consent"
+    assert result["can_govern_truth"] is False
+
+
+def test_orchestration_success_mapping_presents_non_truth_governing_success():
+    result = present_tool_orchestration_result(
+        {
+            "request_id": "req-orch-success",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "correlation_id": "chat-orch-success",
+            "response_status": "success",
+            "audit_accepted": True,
+            "tool_response": {"status": "success", "can_govern_truth": False},
+            "audit_sink_result": {"status": "accepted", "can_govern_truth": False},
+            "can_govern_truth": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "success"
+    assert result["severity"] == "info"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["metadata"]["audit_accepted"] is True
+    assert result["can_govern_truth"] is False
+
+
+def test_orchestration_refusal_mapping_presents_controlled_refusal():
+    result = present_tool_orchestration_result(
+        {
+            "request_id": "req-orch-blocked",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "response_status": "blocked",
+            "error": {
+                "error_type": "not_eligible",
+                "message": "Tool is not eligible in this scope.",
+            },
+            "can_govern_truth": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "refusal"
+    assert result["severity"] == "warning"
+    assert result["source_status"] == "blocked"
+    assert result["metadata"]["reason"] == "not_eligible"
+    assert result["can_govern_truth"] is False
+
+
+def test_orchestration_error_mapping_presents_controlled_error():
+    result = present_tool_orchestration_result(
+        {
+            "request_id": "req-orch-error",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "response_status": "error",
+            "error": {
+                "error_type": "execution_error",
+                "message": "Tool execution failed.",
+            },
+            "can_govern_truth": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "error"
+    assert result["severity"] == "error"
+    assert result["source_status"] == "error"
+    assert result["metadata"]["error_type"] == "execution_error"
+    assert result["can_govern_truth"] is False
+
+
+def test_presentation_output_is_json_serializable():
+    result = present_tool_adapter_result(_ready_adapter_result()).to_dict()
+
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_invalid_payload_produces_controlled_error():
+    result = present_tool_adapter_result(["bad"]).to_dict()
+
+    assert result["status"] == "error"
+    assert result["severity"] == "error"
+    assert result["metadata"]["error_type"] == "invalid_input"
+    assert result["can_govern_truth"] is False
+
+
+def test_presentation_contract_rejects_truth_governance():
+    presentation = ToolUsePresentation(
+        status="success",
+        severity="info",
+        summary="Bad",
+        detail="Bad",
+        source_status="success",
+        can_govern_truth=True,
+    )
+
+    try:
+        presentation.to_dict()
+    except Exception as exc:
+        assert "cannot govern truth" in str(exc)
+    else:
+        raise AssertionError("Expected presentation contract to reject truth governance.")
+
+
+def test_module_does_not_expose_chat_router_or_llm_parser_symbols():
+    import src.application.tools.tool_use_presentation as presentation
+
+    forbidden_names = {
+        "execute_tool_with_audit",
+        "chat_page",
+        "chat_panel",
+        "tool_router",
+        "autonomous_tool_router",
+        "parse_llm_tool_call",
+        "llm_tool_call",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+    }
+
+    for name in forbidden_names:
+        assert not hasattr(presentation, name)


### PR DESCRIPTION
## Summary

Adds a non-UI presentation contract for tool-use outcomes.

This PR converts adapter and orchestration outcomes into stable application presentation envelopes for later chat integration without executing tools, calling the orchestrator, wiring chat/UI, persisting audit records, or touching packaging.

## Scope

Added:

- `src/application/tools/tool_use_presentation.py`
- `src/tests/test_tool_use_presentation_contract.py`

## Contract symbols

```text
ToolUsePresentationContractError
ToolUsePresentation
present_tool_adapter_result
present_tool_orchestration_result
```

## Behavior

- Adapter `ready` result presents as non-truth-governing ready envelope.
- Adapter `clarification` result presents as warning/clarification envelope with next action.
- Adapter `error` result presents as controlled error envelope.
- Adapter refusal-like mappings are supported.
- Orchestration success mapping presents as non-truth-governing success envelope.
- Orchestration blocked/refused/error mappings present as controlled refusal/error envelopes.
- Invalid payloads produce controlled presentation errors.
- All presentation envelopes are JSON-serializable and non-truth-governing.

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\tool_use_presentation.py src\tests\test_tool_use_presentation_contract.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_contract.py
189 passed in 0.39s
```

No-BOM proof:

```text
No BOM: src\application\tools\tool_use_presentation.py
No BOM: src\tests\test_tool_use_presentation_contract.py
```

Diff hygiene:

```text
git diff --cached --check
# no output
```

## Non-scope preserved

- No tool execution
- No call to `execute_tool_with_audit(...)`
- No chat wiring
- No chat-page imports
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new calculator operations
- No new unit conversions
- No new quantity formulas
- No behavior changes in adapter or orchestrator
- No dependency changes
- No packaging changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium only if widened later into chat UI, autonomous routing, or execution
- Product risk: low; non-truth-governing presentation-only contract

Related: issue #79.