### PR TITLE
Add tool use presentation export boundary

### DIFF
--- a/src/application/tools/__init__.py
+++ b/src/application/tools/__init__.py
@@ -24,7 +24,14 @@ _ADAPTER_EXPORTS = {
     "adapt_tool_request",
 }
 
-__all__ = sorted(_ORCHESTRATOR_EXPORTS | _ADAPTER_EXPORTS)
+_PRESENTATION_EXPORTS = {
+    "ToolUsePresentationContractError",
+    "ToolUsePresentation",
+    "present_tool_adapter_result",
+    "present_tool_orchestration_result",
+}
+
+__all__ = sorted(_ORCHESTRATOR_EXPORTS | _ADAPTER_EXPORTS | _PRESENTATION_EXPORTS)
 
 
 def __getattr__(name: str) -> Any:
@@ -53,6 +60,22 @@ def __getattr__(name: str) -> Any:
             "ToolRequestAdapterContractError": ToolRequestAdapterContractError,
             "ToolRequestAdapterResult": ToolRequestAdapterResult,
             "adapt_tool_request": adapt_tool_request,
+        }
+        return exports[name]
+
+    if name in _PRESENTATION_EXPORTS:
+        from src.application.tools.tool_use_presentation import (
+            ToolUsePresentationContractError,
+            ToolUsePresentation,
+            present_tool_adapter_result,
+            present_tool_orchestration_result,
+        )
+
+        exports = {
+            "ToolUsePresentationContractError": ToolUsePresentationContractError,
+            "ToolUsePresentation": ToolUsePresentation,
+            "present_tool_adapter_result": present_tool_adapter_result,
+            "present_tool_orchestration_result": present_tool_orchestration_result,
         }
         return exports[name]
 

--- a/src/tests/test_tool_execution_orchestrator_exports.py
+++ b/src/tests/test_tool_execution_orchestrator_exports.py
@@ -1,117 +1,116 @@
 from __future__ import annotations
 
+import decimal
+import importlib
+import sys
+
 import src.application.tools as tools
-from src.application.tools import (
-    ToolExecutionOrchestrationResult,
-    ToolExecutionOrchestratorContractError,
-    execute_tool_with_audit,
-)
-from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
-from src.application.tools.tool_execution_orchestrator import (
-    ToolExecutionOrchestrationResult as DirectToolExecutionOrchestrationResult,
-    ToolExecutionOrchestratorContractError as DirectToolExecutionOrchestratorContractError,
-    execute_tool_with_audit as direct_execute_tool_with_audit,
-)
-from src.application.tools.tool_invocation_contract import ToolInvocationRequest
 
 
-def _request():
-    return ToolInvocationRequest(
-        request_id="req-export-001",
-        tool_id=CALCULATOR_TOOL_ID,
-        arguments={"operation": "add", "operands": [1, 2]},
-        correlation_id="chat-export-001",
-        requested_by="test",
-        consent_granted=False,
-    )
-
-
-def test_package_boundary_exports_stable_orchestrator_symbols():
-    assert execute_tool_with_audit is direct_execute_tool_with_audit
-    assert ToolExecutionOrchestrationResult is DirectToolExecutionOrchestrationResult
-    assert (
-        ToolExecutionOrchestratorContractError
-        is DirectToolExecutionOrchestratorContractError
-    )
-
-
-def test_package_boundary_all_is_explicit_and_minimal():
-    assert tools.__all__ == sorted(
-        [
+EXPECTED_PUBLIC_EXPORTS = sorted(
+    [
         "ToolExecutionOrchestrationResult",
         "ToolExecutionOrchestratorContractError",
         "ToolRequestAdapterContractError",
         "ToolRequestAdapterResult",
+        "ToolUsePresentation",
+        "ToolUsePresentationContractError",
         "adapt_tool_request",
         "execute_tool_with_audit",
+        "present_tool_adapter_result",
+        "present_tool_orchestration_result",
     ]
-    )
+)
 
 
-def test_execute_tool_with_audit_works_through_package_import_path():
-    result = execute_tool_with_audit(_request(), event_id="evt-export-001").to_dict()
-
-    assert result["request_id"] == "req-export-001"
-    assert result["tool_id"] == CALCULATOR_TOOL_ID
-    assert result["response_status"] == "success"
-    assert result["audit_accepted"] is True
-    assert result["tool_response"]["result"]["computed_result"] == "3"
-    assert result["can_govern_truth"] is False
-    assert result["tool_response"]["can_govern_truth"] is False
-    assert result["audit_sink_result"]["can_govern_truth"] is False
+def _purge_tool_package_and_lazy_targets() -> None:
+    for module_name in [
+        "src.application.tools",
+        "src.application.tools.tool_execution_orchestrator",
+        "src.application.tools.tool_request_adapter",
+        "src.application.tools.tool_use_presentation",
+    ]:
+        sys.modules.pop(module_name, None)
 
 
-def test_private_orchestrator_helpers_are_not_exported():
-    private_names = {
-        "_validate_request_for_orchestration",
-        "_build_and_accept_audit_event",
-        "_validate_sink",
-        "_sink_name",
-        "_require_non_empty",
-    }
-
-    for name in private_names:
-        assert not hasattr(tools, name)
+def test_package_boundary_all_is_explicit_and_minimal():
+    assert tools.__all__ == EXPECTED_PUBLIC_EXPORTS
 
 
-def test_export_boundary_does_not_introduce_chat_router_or_llm_parser_symbols():
-    forbidden_names = {
-        "chat",
-        "chat_page",
-        "tool_router",
-        "autonomous_tool_router",
-        "llm_tool_call",
-        "parse_llm_tool_call",
-        "mcp",
-        "agent_loop",
-        "audit_persistence",
-    }
+def test_package_boundary_rejects_unknown_symbols():
+    try:
+        getattr(tools, "not_a_public_tool_symbol")
+    except AttributeError as exc:
+        assert "not_a_public_tool_symbol" in str(exc)
+    else:
+        raise AssertionError("Expected unknown package export to raise AttributeError.")
 
-    for name in forbidden_names:
-        assert not hasattr(tools, name)
+
+def test_plain_package_import_does_not_eagerly_load_lazy_targets():
+    _purge_tool_package_and_lazy_targets()
+
+    imported_tools = importlib.import_module("src.application.tools")
+
+    assert imported_tools.__all__ == EXPECTED_PUBLIC_EXPORTS
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+    assert "src.application.tools.tool_request_adapter" not in sys.modules
+    assert "src.application.tools.tool_use_presentation" not in sys.modules
+
 
 def test_plain_package_import_does_not_mutate_decimal_precision():
-    import decimal
-    import importlib
-    import sys
-
-    sys.modules.pop("src.application.tools", None)
+    _purge_tool_package_and_lazy_targets()
 
     original_precision = decimal.getcontext().prec
     decimal.getcontext().prec = 7
     try:
         imported_tools = importlib.import_module("src.application.tools")
 
-        assert imported_tools.__all__ == sorted(
-            [
-        "ToolExecutionOrchestrationResult",
-        "ToolExecutionOrchestratorContractError",
-        "ToolRequestAdapterContractError",
-        "ToolRequestAdapterResult",
-        "adapt_tool_request",
-        "execute_tool_with_audit",
-    ]
-        )
+        assert imported_tools.__all__ == EXPECTED_PUBLIC_EXPORTS
         assert decimal.getcontext().prec == 7
     finally:
         decimal.getcontext().prec = original_precision
+
+
+def test_lazy_export_import_loads_orchestrator_only_when_requested():
+    _purge_tool_package_and_lazy_targets()
+
+    imported_tools = importlib.import_module("src.application.tools")
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+
+    _ = imported_tools.execute_tool_with_audit
+
+    assert "src.application.tools.tool_execution_orchestrator" in sys.modules
+
+
+def test_orchestrator_public_symbols_import_through_package_boundary():
+    from src.application.tools import (
+        ToolExecutionOrchestrationResult,
+        ToolExecutionOrchestratorContractError,
+        execute_tool_with_audit,
+    )
+    from src.application.tools.tool_execution_orchestrator import (
+        ToolExecutionOrchestrationResult as DirectResult,
+        ToolExecutionOrchestratorContractError as DirectError,
+        execute_tool_with_audit as direct_execute,
+    )
+
+    assert ToolExecutionOrchestrationResult is DirectResult
+    assert ToolExecutionOrchestratorContractError is DirectError
+    assert execute_tool_with_audit is direct_execute
+
+
+def test_private_orchestrator_helpers_are_not_exported():
+    forbidden_names = {
+        "_as_mapping",
+        "_mapping_or_none",
+        "_from_mapping",
+        "_string_or_none",
+        "_string_or_default",
+        "_invalid_input",
+        "_ORCHESTRATOR_EXPORTS",
+        "_ADAPTER_EXPORTS",
+        "_PRESENTATION_EXPORTS",
+    }
+
+    for name in forbidden_names:
+        assert name not in tools.__all__

--- a/src/tests/test_tool_use_presentation_exports.py
+++ b/src/tests/test_tool_use_presentation_exports.py
@@ -34,7 +34,7 @@ def _purge_tool_package_and_lazy_targets() -> None:
         sys.modules.pop(module_name, None)
 
 
-def test_plain_package_import_does_not_eagerly_load_adapter_or_orchestrator():
+def test_plain_package_import_does_not_eagerly_load_lazy_targets():
     _purge_tool_package_and_lazy_targets()
 
     imported_tools = importlib.import_module("src.application.tools")
@@ -49,78 +49,117 @@ def test_plain_package_import_does_not_mutate_decimal_precision():
     _purge_tool_package_and_lazy_targets()
 
     original_precision = decimal.getcontext().prec
-    decimal.getcontext().prec = 9
+    decimal.getcontext().prec = 11
     try:
         imported_tools = importlib.import_module("src.application.tools")
 
         assert imported_tools.__all__ == EXPECTED_PUBLIC_EXPORTS
-        assert decimal.getcontext().prec == 9
+        assert decimal.getcontext().prec == 11
     finally:
         decimal.getcontext().prec = original_precision
 
 
-def test_adapter_public_symbols_import_through_package_boundary():
+def test_presentation_public_symbols_import_through_package_boundary():
     from src.application.tools import (
-        ToolRequestAdapterContractError,
-        ToolRequestAdapterResult,
-        adapt_tool_request,
+        ToolUsePresentation,
+        ToolUsePresentationContractError,
+        present_tool_adapter_result,
+        present_tool_orchestration_result,
     )
-    from src.application.tools.tool_request_adapter import (
-        ToolRequestAdapterContractError as DirectError,
-        ToolRequestAdapterResult as DirectResult,
-        adapt_tool_request as direct_adapt,
+    from src.application.tools.tool_use_presentation import (
+        ToolUsePresentation as DirectPresentation,
+        ToolUsePresentationContractError as DirectError,
+        present_tool_adapter_result as direct_present_adapter,
+        present_tool_orchestration_result as direct_present_orchestrator,
     )
 
-    assert ToolRequestAdapterContractError is DirectError
-    assert ToolRequestAdapterResult is DirectResult
-    assert adapt_tool_request is direct_adapt
+    assert ToolUsePresentation is DirectPresentation
+    assert ToolUsePresentationContractError is DirectError
+    assert present_tool_adapter_result is direct_present_adapter
+    assert present_tool_orchestration_result is direct_present_orchestrator
 
 
-def test_adapter_import_through_package_boundary_works_and_cannot_govern_truth():
-    from src.application.tools import adapt_tool_request
+def test_present_tool_adapter_result_works_through_package_boundary():
+    from src.application.tools import adapt_tool_request, present_tool_adapter_result
 
-    result = adapt_tool_request(
+    adapter_result = adapt_tool_request(
         {
-            "request_id": "req-adapter-export-001",
+            "request_id": "req-export-presentation",
             "tool_id": CALCULATOR_TOOL_ID,
             "arguments": {"operation": "add", "operands": [1, 2]},
-            "correlation_id": "chat-adapter-export-001",
-            "requested_by": "adapter_export_test",
+            "correlation_id": "chat-export-presentation",
+            "requested_by": "presentation_export_test",
             "consent_granted": False,
         }
-    ).to_dict()
+    )
+    result = present_tool_adapter_result(adapter_result).to_dict()
 
     assert result["status"] == "ready"
-    assert result["tool_request"]["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
     assert result["can_govern_truth"] is False
     assert json.loads(json.dumps(result, sort_keys=True)) == result
 
 
-def test_existing_orchestrator_exports_remain_available():
+def test_present_tool_orchestration_result_works_through_package_boundary():
+    from src.application.tools import present_tool_orchestration_result
+
+    result = present_tool_orchestration_result(
+        {
+            "request_id": "req-export-orch",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "correlation_id": "chat-export-orch",
+            "response_status": "success",
+            "audit_accepted": True,
+            "tool_response": {"status": "success", "can_govern_truth": False},
+            "audit_sink_result": {"status": "accepted", "can_govern_truth": False},
+            "can_govern_truth": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "success"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["can_govern_truth"] is False
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_existing_orchestrator_and_adapter_exports_remain_available():
     from src.application.tools import (
         ToolExecutionOrchestrationResult,
         ToolExecutionOrchestratorContractError,
+        ToolRequestAdapterContractError,
+        ToolRequestAdapterResult,
+        adapt_tool_request,
         execute_tool_with_audit,
     )
     from src.application.tools.tool_execution_orchestrator import (
-        ToolExecutionOrchestrationResult as DirectResult,
-        ToolExecutionOrchestratorContractError as DirectError,
+        ToolExecutionOrchestrationResult as DirectOrchestrationResult,
+        ToolExecutionOrchestratorContractError as DirectOrchestrationError,
         execute_tool_with_audit as direct_execute,
     )
+    from src.application.tools.tool_request_adapter import (
+        ToolRequestAdapterContractError as DirectAdapterError,
+        ToolRequestAdapterResult as DirectAdapterResult,
+        adapt_tool_request as direct_adapt,
+    )
 
-    assert ToolExecutionOrchestrationResult is DirectResult
-    assert ToolExecutionOrchestratorContractError is DirectError
+    assert ToolExecutionOrchestrationResult is DirectOrchestrationResult
+    assert ToolExecutionOrchestratorContractError is DirectOrchestrationError
     assert execute_tool_with_audit is direct_execute
+    assert ToolRequestAdapterContractError is DirectAdapterError
+    assert ToolRequestAdapterResult is DirectAdapterResult
+    assert adapt_tool_request is direct_adapt
 
 
-def test_private_adapter_helpers_are_not_exported():
+def test_private_presentation_helpers_are_not_exported():
     import src.application.tools as tools
 
     forbidden_names = {
+        "_as_mapping",
+        "_mapping_or_none",
+        "_from_mapping",
         "_string_or_none",
         "_string_or_default",
-        "_clarification",
-        "_error",
+        "_invalid_input",
     }
 
     for name in forbidden_names:


### PR DESCRIPTION
## Summary

Adds lazy package exports for the tool-use presentation contract through `src.application.tools`.

This PR preserves existing lazy orchestrator and adapter export boundaries and extends the package boundary to include presentation symbols without eager imports.

## Scope

Updated/added:

- `src/application/tools/__init__.py`
- `src/tests/test_tool_execution_orchestrator_exports.py`
- `src/tests/test_tool_request_adapter_exports.py`
- `src/tests/test_tool_use_presentation_exports.py`

## Public exports

```text
ToolExecutionOrchestrationResult
ToolExecutionOrchestratorContractError
ToolRequestAdapterContractError
ToolRequestAdapterResult
ToolUsePresentation
ToolUsePresentationContractError
adapt_tool_request
execute_tool_with_audit
present_tool_adapter_result
present_tool_orchestration_result
```

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\__init__.py src\application\tools\tool_use_presentation.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_exports.py
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_contract.py src\tests\test_tool_use_presentation_exports.py
198 passed in 0.42s
```

Diff hygiene:

```text
git diff --cached --check
# no output
```

Remote branch inspection confirms lazy export implementation and presentation export regression coverage.

## Non-scope preserved

- No tool execution
- No call to `execute_tool_with_audit(...)`
- No chat wiring
- No chat-page imports
- No autonomous tool router
- No LLM tool-call parser
- No MCP integration
- No agent loop
- No internet use
- No DB writes
- No file writes
- No audit persistence implementation
- No UI changes
- No source-of-truth mutation
- No candidate fact certification
- No new tool behavior
- No behavior changes in adapter, orchestrator, or presentation contract
- No dependency changes
- No packaging changes

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: medium only if lazy import boundary is later weakened
- Product risk: low; export-only packet does not enable chat/tool execution

Related: issue #81.