### PR TITLE
Add chat tool bridge contract

### DIFF
--- a/src/application/tools/chat_tool_bridge.py
+++ b/src/application/tools/chat_tool_bridge.py
@@ -1,0 +1,114 @@
+"""Non-executing bridge for structured chat-owned tool requests.
+
+This module is the first bounded bridge between future chat-side structured
+tool requests and the approved tool foundation. It adapts and presents only.
+
+It does not execute tools, call the tool execution orchestrator, parse LLM tool
+calls, import chat UI, persist audits, touch storage, mutate facts, or govern
+truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.application.tools.tool_request_adapter import adapt_tool_request
+from src.application.tools.tool_use_presentation import present_tool_adapter_result
+
+
+class ChatToolBridgeContractError(ValueError):
+    """Raised when the chat tool bridge result violates its contract."""
+
+
+_ALLOWED_STATUSES = {"ready", "clarification", "refusal", "error", "success"}
+
+
+@dataclass(frozen=True)
+class ChatToolBridgeResult:
+    status: str
+    adapter_result: Mapping[str, Any]
+    presentation: Mapping[str, Any]
+    request_id: str | None = None
+    tool_id: str | None = None
+    correlation_id: str | None = None
+    source: str = "chat_tool_bridge"
+    executed: bool = False
+    can_govern_truth: bool = False
+
+    def validate(self) -> None:
+        if self.status not in _ALLOWED_STATUSES:
+            raise ChatToolBridgeContractError("status is not an approved bridge status.")
+        if not isinstance(self.adapter_result, Mapping):
+            raise ChatToolBridgeContractError("adapter_result must be a mapping.")
+        if not isinstance(self.presentation, Mapping):
+            raise ChatToolBridgeContractError("presentation must be a mapping.")
+        if self.request_id is not None and not isinstance(self.request_id, str):
+            raise ChatToolBridgeContractError("request_id must be a string or None.")
+        if self.tool_id is not None and not isinstance(self.tool_id, str):
+            raise ChatToolBridgeContractError("tool_id must be a string or None.")
+        if self.correlation_id is not None and not isinstance(self.correlation_id, str):
+            raise ChatToolBridgeContractError("correlation_id must be a string or None.")
+        if self.source != "chat_tool_bridge":
+            raise ChatToolBridgeContractError("source must remain chat_tool_bridge.")
+        if self.executed is not False:
+            raise ChatToolBridgeContractError("chat tool bridge must not execute tools.")
+        if self.can_govern_truth is not False:
+            raise ChatToolBridgeContractError("chat tool bridge cannot govern truth.")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "status": self.status,
+            "adapter_result": dict(self.adapter_result),
+            "presentation": dict(self.presentation),
+            "request_id": self.request_id,
+            "tool_id": self.tool_id,
+            "correlation_id": self.correlation_id,
+            "source": self.source,
+            "executed": False,
+            "can_govern_truth": False,
+        }
+
+
+def build_chat_tool_bridge_envelope(payload: Mapping[str, Any]) -> ChatToolBridgeResult:
+    """Adapt and present a structured chat-side tool request without execution."""
+
+    adapter_result = adapt_tool_request(payload)
+    adapter_payload = adapter_result.to_dict()
+
+    presentation = present_tool_adapter_result(adapter_result)
+    presentation_payload = presentation.to_dict()
+
+    tool_request = adapter_payload.get("tool_request")
+    tool_request_mapping = tool_request if isinstance(tool_request, Mapping) else None
+
+    return ChatToolBridgeResult(
+        status=_string_or_default(presentation_payload.get("status"), "error"),
+        adapter_result=adapter_payload,
+        presentation=presentation_payload,
+        request_id=_string_or_none(_from_mapping(tool_request_mapping, "request_id")),
+        tool_id=_string_or_none(_from_mapping(tool_request_mapping, "tool_id")),
+        correlation_id=_string_or_none(_from_mapping(tool_request_mapping, "correlation_id")),
+        source="chat_tool_bridge",
+        executed=False,
+        can_govern_truth=False,
+    )
+
+
+def _from_mapping(mapping: Mapping[str, Any] | None, key: str) -> Any:
+    if mapping is None:
+        return None
+    return mapping.get(key)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _string_or_default(value: Any, default: str) -> str:
+    stripped = _string_or_none(value)
+    return stripped if stripped is not None else default

--- a/src/tests/test_chat_tool_bridge_contract.py
+++ b/src/tests/test_chat_tool_bridge_contract.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+from src.application.tools.chat_tool_bridge import (
+    ChatToolBridgeResult,
+    build_chat_tool_bridge_envelope,
+)
+
+
+def _valid_payload():
+    return {
+        "request_id": "req-bridge-001",
+        "tool_id": CALCULATOR_TOOL_ID,
+        "arguments": {"operation": "add", "operands": [1, 2]},
+        "correlation_id": "chat-bridge-001",
+        "requested_by": "chat_tool_bridge_test",
+        "consent_granted": False,
+    }
+
+
+def test_valid_structured_request_builds_ready_non_executing_bridge_envelope():
+    result = build_chat_tool_bridge_envelope(_valid_payload()).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["source"] == "chat_tool_bridge"
+    assert result["executed"] is False
+    assert result["can_govern_truth"] is False
+    assert result["request_id"] == "req-bridge-001"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["correlation_id"] == "chat-bridge-001"
+    assert result["adapter_result"]["status"] == "ready"
+    assert result["adapter_result"]["can_govern_truth"] is False
+    assert result["presentation"]["status"] == "ready"
+    assert result["presentation"]["can_govern_truth"] is False
+
+
+def test_missing_tool_id_returns_controlled_clarification_bridge_envelope():
+    payload = _valid_payload()
+    payload.pop("tool_id")
+
+    result = build_chat_tool_bridge_envelope(payload).to_dict()
+
+    assert result["status"] == "clarification"
+    assert result["executed"] is False
+    assert result["can_govern_truth"] is False
+    assert result["adapter_result"]["status"] == "clarification"
+    assert result["adapter_result"]["clarification"]["missing_field"] == "tool_id"
+    assert result["presentation"]["status"] == "clarification"
+
+
+def test_non_mapping_payload_returns_controlled_error_bridge_envelope():
+    result = build_chat_tool_bridge_envelope(["bad"]).to_dict()
+
+    assert result["status"] == "error"
+    assert result["executed"] is False
+    assert result["can_govern_truth"] is False
+    assert result["adapter_result"]["status"] == "error"
+    assert result["adapter_result"]["error"]["error_type"] == "invalid_payload"
+    assert result["presentation"]["status"] == "error"
+
+
+def test_non_mapping_arguments_returns_controlled_error_bridge_envelope():
+    payload = _valid_payload()
+    payload["arguments"] = ["bad"]
+
+    result = build_chat_tool_bridge_envelope(payload).to_dict()
+
+    assert result["status"] == "error"
+    assert result["executed"] is False
+    assert result["can_govern_truth"] is False
+    assert result["adapter_result"]["error"]["error_type"] == "invalid_arguments"
+    assert result["presentation"]["metadata"]["error_type"] == "invalid_arguments"
+
+
+def test_bridge_output_is_json_serializable():
+    result = build_chat_tool_bridge_envelope(_valid_payload()).to_dict()
+
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_bridge_contract_rejects_truth_governance():
+    result = ChatToolBridgeResult(
+        status="ready",
+        adapter_result={"status": "ready", "can_govern_truth": False},
+        presentation={"status": "ready", "can_govern_truth": False},
+        can_govern_truth=True,
+    )
+
+    try:
+        result.to_dict()
+    except Exception as exc:
+        assert "cannot govern truth" in str(exc)
+    else:
+        raise AssertionError("Expected bridge result to reject truth governance.")
+
+
+def test_bridge_contract_rejects_execution_claim():
+    result = ChatToolBridgeResult(
+        status="ready",
+        adapter_result={"status": "ready", "can_govern_truth": False},
+        presentation={"status": "ready", "can_govern_truth": False},
+        executed=True,
+    )
+
+    try:
+        result.to_dict()
+    except Exception as exc:
+        assert "must not execute tools" in str(exc)
+    else:
+        raise AssertionError("Expected bridge result to reject execution.")
+
+
+def test_bridge_module_does_not_expose_chat_router_or_llm_parser_symbols():
+    import src.application.tools.chat_tool_bridge as bridge
+
+    forbidden_names = {
+        "execute_tool_with_audit",
+        "chat_page",
+        "chat_panel",
+        "tool_router",
+        "autonomous_tool_router",
+        "parse_llm_tool_call",
+        "llm_tool_call",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+        "certify_fact",
+        "candidate_fact",
+    }
+
+    for name in forbidden_names:
+        assert not hasattr(bridge, name)
+
+
+def test_bridge_does_not_import_orchestrator_when_building_envelope():
+    modules_to_purge = [
+        "src.application.tools.chat_tool_bridge",
+        "src.application.tools.tool_request_adapter",
+        "src.application.tools.tool_use_presentation",
+        "src.application.tools.tool_execution_orchestrator",
+    ]
+
+    for module_name in modules_to_purge:
+        sys.modules.pop(module_name, None)
+
+    bridge = importlib.import_module("src.application.tools.chat_tool_bridge")
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+
+    result = bridge.build_chat_tool_bridge_envelope(_valid_payload()).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["executed"] is False
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules


### PR DESCRIPTION
## Summary

Adds the Phase 1C-1 non-executing chat tool bridge contract.

This PR creates a bounded bridge between future structured chat-side tool requests and the existing Upgrade 1B tool foundation. The bridge adapts a structured payload through `adapt_tool_request(...)`, presents it through `present_tool_adapter_result(...)`, and returns a JSON-serializable, non-truth-governing bridge envelope.

## Scope

Added:

- `src/application/tools/chat_tool_bridge.py`
- `src/tests/test_chat_tool_bridge_contract.py`

## Behavior

- Accepts structured request payloads.
- Uses the existing tool request adapter.
- Uses the existing tool-use presentation contract.
- Returns a stable bridge envelope with `executed == False` and `can_govern_truth == False`.
- Handles missing/invalid payloads through controlled adapter/presentation envelopes.
- Provides contract checks against execution and truth governance.
- Proves bridge output is JSON-serializable.
- Proves the bridge module does not expose chat/router/LLM parser/agent symbols.
- Proves building a bridge envelope does not import the tool execution orchestrator.

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\chat_tool_bridge.py src\tests\test_chat_tool_bridge_contract.py
py -m pytest -q src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_use_presentation_contract.py src\tests\test_chat_tool_bridge_contract.py
34 passed in 0.10s
py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_contract.py src\tests\test_tool_use_presentation_exports.py src\tests\test_tool_foundation_consolidation_gate.py src\tests\test_chat_tool_bridge_contract.py
214 passed in 0.43s
```

No-BOM proof:

```text
No BOM: src\application\tools\chat_tool_bridge.py
No BOM: src\tests\test_chat_tool_bridge_contract.py
```

Packaging boundary:

```text
git diff --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

## Non-scope preserved

- No ChatPage / ChatPanel edits
- No UI changes
- No autonomous router
- No LLM tool-call parser
- No call to `execute_tool_with_audit(...)`
- No DB writes
- No file writes beyond the two source/test files
- No audit persistence
- No package export change in this packet
- No dependency changes
- No packaging changes
- No Quality Upgrade work

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: controlled; bridge remains non-executing and non-truth-governing
- Product risk: low; no visible product behavior is enabled

Related: Phase 1C-1 Chat Tool Bridge Contract.