### PR TITLE
Add chat tool bridge export boundary

### DIFF
--- a/src/application/tools/__init__.py
+++ b/src/application/tools/__init__.py
@@ -31,7 +31,18 @@ _PRESENTATION_EXPORTS = {
     "present_tool_orchestration_result",
 }
 
-__all__ = sorted(_ORCHESTRATOR_EXPORTS | _ADAPTER_EXPORTS | _PRESENTATION_EXPORTS)
+_BRIDGE_EXPORTS = {
+    "ChatToolBridgeContractError",
+    "ChatToolBridgeResult",
+    "build_chat_tool_bridge_envelope",
+}
+
+__all__ = sorted(
+    _ORCHESTRATOR_EXPORTS
+    | _ADAPTER_EXPORTS
+    | _PRESENTATION_EXPORTS
+    | _BRIDGE_EXPORTS
+)
 
 
 def __getattr__(name: str) -> Any:
@@ -76,6 +87,20 @@ def __getattr__(name: str) -> Any:
             "ToolUsePresentation": ToolUsePresentation,
             "present_tool_adapter_result": present_tool_adapter_result,
             "present_tool_orchestration_result": present_tool_orchestration_result,
+        }
+        return exports[name]
+
+    if name in _BRIDGE_EXPORTS:
+        from src.application.tools.chat_tool_bridge import (
+            ChatToolBridgeContractError,
+            ChatToolBridgeResult,
+            build_chat_tool_bridge_envelope,
+        )
+
+        exports = {
+            "ChatToolBridgeContractError": ChatToolBridgeContractError,
+            "ChatToolBridgeResult": ChatToolBridgeResult,
+            "build_chat_tool_bridge_envelope": build_chat_tool_bridge_envelope,
         }
         return exports[name]
 

--- a/src/tests/test_chat_tool_bridge_exports.py
+++ b/src/tests/test_chat_tool_bridge_exports.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import decimal
+import importlib
+import json
+import sys
+
+from src.application.tools.calculator_tool import TOOL_ID as CALCULATOR_TOOL_ID
+
+
+EXPECTED_PUBLIC_EXPORTS = sorted(
+    [
+        "ChatToolBridgeContractError",
+        "ChatToolBridgeResult",
+        "ToolExecutionOrchestrationResult",
+        "ToolExecutionOrchestratorContractError",
+        "ToolRequestAdapterContractError",
+        "ToolRequestAdapterResult",
+        "ToolUsePresentation",
+        "ToolUsePresentationContractError",
+        "adapt_tool_request",
+        "build_chat_tool_bridge_envelope",
+        "execute_tool_with_audit",
+        "present_tool_adapter_result",
+        "present_tool_orchestration_result",
+    ]
+)
+
+
+LAZY_TARGETS = {
+    "src.application.tools.chat_tool_bridge",
+    "src.application.tools.tool_execution_orchestrator",
+    "src.application.tools.tool_request_adapter",
+    "src.application.tools.tool_use_presentation",
+}
+
+
+def _purge_tool_package_and_lazy_targets() -> None:
+    for module_name in ["src.application.tools", *sorted(LAZY_TARGETS)]:
+        sys.modules.pop(module_name, None)
+
+
+def test_plain_package_import_does_not_eagerly_load_bridge_or_other_lazy_targets():
+    _purge_tool_package_and_lazy_targets()
+
+    imported_tools = importlib.import_module("src.application.tools")
+
+    assert imported_tools.__all__ == EXPECTED_PUBLIC_EXPORTS
+    for module_name in LAZY_TARGETS:
+        assert module_name not in sys.modules
+
+
+def test_plain_package_import_does_not_mutate_decimal_precision():
+    _purge_tool_package_and_lazy_targets()
+
+    original_precision = decimal.getcontext().prec
+    decimal.getcontext().prec = 15
+    try:
+        imported_tools = importlib.import_module("src.application.tools")
+
+        assert imported_tools.__all__ == EXPECTED_PUBLIC_EXPORTS
+        assert decimal.getcontext().prec == 15
+    finally:
+        decimal.getcontext().prec = original_precision
+
+
+def test_bridge_public_symbols_import_through_package_boundary():
+    from src.application.tools import (
+        ChatToolBridgeContractError,
+        ChatToolBridgeResult,
+        build_chat_tool_bridge_envelope,
+    )
+    from src.application.tools.chat_tool_bridge import (
+        ChatToolBridgeContractError as DirectError,
+        ChatToolBridgeResult as DirectResult,
+        build_chat_tool_bridge_envelope as direct_build,
+    )
+
+    assert ChatToolBridgeContractError is DirectError
+    assert ChatToolBridgeResult is DirectResult
+    assert build_chat_tool_bridge_envelope is direct_build
+
+
+def test_bridge_import_through_package_boundary_builds_non_executing_envelope():
+    from src.application.tools import build_chat_tool_bridge_envelope
+
+    result = build_chat_tool_bridge_envelope(
+        {
+            "request_id": "req-bridge-export-001",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "arguments": {"operation": "add", "operands": [1, 2]},
+            "correlation_id": "chat-bridge-export-001",
+            "requested_by": "bridge_export_test",
+            "consent_granted": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "ready"
+    assert result["tool_id"] == CALCULATOR_TOOL_ID
+    assert result["executed"] is False
+    assert result["can_govern_truth"] is False
+    assert json.loads(json.dumps(result, sort_keys=True)) == result
+
+
+def test_bridge_export_access_does_not_load_orchestrator():
+    _purge_tool_package_and_lazy_targets()
+
+    imported_tools = importlib.import_module("src.application.tools")
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+
+    result = imported_tools.build_chat_tool_bridge_envelope(
+        {
+            "request_id": "req-bridge-export-lazy",
+            "tool_id": CALCULATOR_TOOL_ID,
+            "arguments": {"operation": "add", "operands": [1, 2]},
+            "correlation_id": "chat-bridge-export-lazy",
+            "requested_by": "bridge_export_test",
+            "consent_granted": False,
+        }
+    ).to_dict()
+
+    assert result["status"] == "ready"
+    assert "src.application.tools.chat_tool_bridge" in sys.modules
+    assert "src.application.tools.tool_request_adapter" in sys.modules
+    assert "src.application.tools.tool_use_presentation" in sys.modules
+    assert "src.application.tools.tool_execution_orchestrator" not in sys.modules
+
+
+def test_private_bridge_helpers_are_not_exported():
+    import src.application.tools as tools
+
+    forbidden_names = {
+        "_from_mapping",
+        "_string_or_none",
+        "_string_or_default",
+        "_BRIDGE_EXPORTS",
+    }
+
+    for name in forbidden_names:
+        assert name not in tools.__all__
+
+
+def test_no_chat_ui_router_llm_parser_or_agent_symbols_are_exported():
+    import src.application.tools as tools
+
+    forbidden_names = {
+        "chat_page",
+        "chat_panel",
+        "tool_router",
+        "autonomous_tool_router",
+        "parse_llm_tool_call",
+        "llm_tool_call",
+        "mcp",
+        "agent_loop",
+        "audit_persistence",
+        "certify_fact",
+        "candidate_fact",
+    }
+
+    for name in forbidden_names:
+        assert name not in tools.__all__
+        try:
+            getattr(tools, name)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError(f"Forbidden symbol was exported: {name}")

--- a/src/tests/test_tool_execution_orchestrator_exports.py
+++ b/src/tests/test_tool_execution_orchestrator_exports.py
@@ -13,6 +13,9 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
         "ToolExecutionOrchestratorContractError",
         "ToolRequestAdapterContractError",
         "ToolRequestAdapterResult",
+        "ChatToolBridgeContractError",
+        "ChatToolBridgeResult",
+        "build_chat_tool_bridge_envelope",
         "ToolUsePresentation",
         "ToolUsePresentationContractError",
         "adapt_tool_request",
@@ -26,7 +29,9 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
 def _purge_tool_package_and_lazy_targets() -> None:
     for module_name in [
         "src.application.tools",
-        "src.application.tools.tool_execution_orchestrator",
+        "src.application.tools.chat_tool_bridge",
+        "src.application.tools.chat_tool_bridge",
+    "src.application.tools.tool_execution_orchestrator",
         "src.application.tools.tool_request_adapter",
         "src.application.tools.tool_use_presentation",
     ]:
@@ -110,6 +115,7 @@ def test_private_orchestrator_helpers_are_not_exported():
         "_ORCHESTRATOR_EXPORTS",
         "_ADAPTER_EXPORTS",
         "_PRESENTATION_EXPORTS",
+        "_BRIDGE_EXPORTS",
     }
 
     for name in forbidden_names:

--- a/src/tests/test_tool_foundation_consolidation_gate.py
+++ b/src/tests/test_tool_foundation_consolidation_gate.py
@@ -14,6 +14,9 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
         "ToolExecutionOrchestratorContractError",
         "ToolRequestAdapterContractError",
         "ToolRequestAdapterResult",
+        "ChatToolBridgeContractError",
+        "ChatToolBridgeResult",
+        "build_chat_tool_bridge_envelope",
         "ToolUsePresentation",
         "ToolUsePresentationContractError",
         "adapt_tool_request",
@@ -25,6 +28,7 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
 
 
 LAZY_TARGETS = {
+    "src.application.tools.chat_tool_bridge",
     "src.application.tools.tool_execution_orchestrator",
     "src.application.tools.tool_request_adapter",
     "src.application.tools.tool_use_presentation",

--- a/src/tests/test_tool_request_adapter_exports.py
+++ b/src/tests/test_tool_request_adapter_exports.py
@@ -14,6 +14,9 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
         "ToolExecutionOrchestratorContractError",
         "ToolRequestAdapterContractError",
         "ToolRequestAdapterResult",
+        "ChatToolBridgeContractError",
+        "ChatToolBridgeResult",
+        "build_chat_tool_bridge_envelope",
         "ToolUsePresentation",
         "ToolUsePresentationContractError",
         "adapt_tool_request",
@@ -27,8 +30,10 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
 def _purge_tool_package_and_lazy_targets() -> None:
     for module_name in [
         "src.application.tools",
+        "src.application.tools.chat_tool_bridge",
         "src.application.tools.tool_request_adapter",
-        "src.application.tools.tool_execution_orchestrator",
+        "src.application.tools.chat_tool_bridge",
+    "src.application.tools.tool_execution_orchestrator",
         "src.application.tools.tool_use_presentation",
     ]:
         sys.modules.pop(module_name, None)

--- a/src/tests/test_tool_use_presentation_exports.py
+++ b/src/tests/test_tool_use_presentation_exports.py
@@ -14,6 +14,9 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
         "ToolExecutionOrchestratorContractError",
         "ToolRequestAdapterContractError",
         "ToolRequestAdapterResult",
+        "ChatToolBridgeContractError",
+        "ChatToolBridgeResult",
+        "build_chat_tool_bridge_envelope",
         "ToolUsePresentation",
         "ToolUsePresentationContractError",
         "adapt_tool_request",
@@ -27,8 +30,10 @@ EXPECTED_PUBLIC_EXPORTS = sorted(
 def _purge_tool_package_and_lazy_targets() -> None:
     for module_name in [
         "src.application.tools",
+        "src.application.tools.chat_tool_bridge",
         "src.application.tools.tool_request_adapter",
-        "src.application.tools.tool_execution_orchestrator",
+        "src.application.tools.chat_tool_bridge",
+    "src.application.tools.tool_execution_orchestrator",
         "src.application.tools.tool_use_presentation",
     ]:
         sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary

Adds the Phase 1C-2 lazy package export boundary for the chat tool bridge contract.

This PR exposes the already-merged `ChatToolBridgeContractError`, `ChatToolBridgeResult`, and `build_chat_tool_bridge_envelope` symbols through `src.application.tools` while preserving lazy import behavior and the no-chat/no-execution boundary.

## Scope

Updated/added:

- `src/application/tools/__init__.py`
- `src/tests/test_chat_tool_bridge_exports.py`
- `src/tests/test_tool_execution_orchestrator_exports.py`
- `src/tests/test_tool_request_adapter_exports.py`
- `src/tests/test_tool_use_presentation_exports.py`
- `src/tests/test_tool_foundation_consolidation_gate.py`

## Verification

Local Windows verification:

```text
py -m py_compile src\application\tools\__init__.py src\tests\test_chat_tool_bridge_exports.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_exports.py src\tests\test_tool_foundation_consolidation_gate.py

py -m pytest -q src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_exports.py src\tests\test_chat_tool_bridge_exports.py src\tests\test_tool_foundation_consolidation_gate.py
36 passed in 0.24s

py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_contract.py src\tests\test_tool_use_presentation_exports.py src\tests\test_tool_foundation_consolidation_gate.py src\tests\test_chat_tool_bridge_contract.py src\tests\test_chat_tool_bridge_exports.py
221 passed in 0.61s
```

Packaging boundary:

```text
git diff --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

## Non-scope preserved

- No ChatPage / ChatPanel edits
- No UI changes
- No autonomous router
- No LLM tool-call parser
- No tool execution changes
- No DB writes
- No audit persistence
- No dependency changes
- No packaging changes
- No Quality Upgrade work

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; lazy export boundary only
- Product risk: low; no visible product behavior is enabled

## Follow-up note

A separate PR #85 review item about rejecting `success` in non-executing bridge results remains valid for a narrow follow-up packet. This PR is export-boundary only and intentionally does not change bridge status semantics.