### PR TITLE
Reject success status in chat tool bridge

### DIFF
--- a/src/application/tools/chat_tool_bridge.py
+++ b/src/application/tools/chat_tool_bridge.py
@@ -21,7 +21,7 @@ class ChatToolBridgeContractError(ValueError):
     """Raised when the chat tool bridge result violates its contract."""
 
 
-_ALLOWED_STATUSES = {"ready", "clarification", "refusal", "error", "success"}
+_ALLOWED_STATUSES = {"ready", "clarification", "refusal", "error"}
 
 
 @dataclass(frozen=True)

--- a/src/tests/test_chat_tool_bridge_contract.py
+++ b/src/tests/test_chat_tool_bridge_contract.py
@@ -114,6 +114,21 @@ def test_bridge_contract_rejects_execution_claim():
         raise AssertionError("Expected bridge result to reject execution.")
 
 
+def test_bridge_contract_rejects_success_status_because_bridge_never_executes():
+    result = ChatToolBridgeResult(
+        status="success",
+        adapter_result={"status": "ready", "can_govern_truth": False},
+        presentation={"status": "ready", "can_govern_truth": False},
+    )
+
+    try:
+        result.to_dict()
+    except Exception as exc:
+        assert "status is not an approved bridge status" in str(exc)
+    else:
+        raise AssertionError("Expected bridge result to reject success status.")
+
+
 def test_bridge_module_does_not_expose_chat_router_or_llm_parser_symbols():
     import src.application.tools.chat_tool_bridge as bridge
 


### PR DESCRIPTION
## Summary

Closes the narrow PR #85 follow-up item by rejecting `success` as a valid `ChatToolBridgeResult` status.

The chat tool bridge is intentionally non-executing. Since it adapts and presents only, a `success` status would imply execution/completion semantics that this layer must not claim.

## Scope

Updated:

- `src/application/tools/chat_tool_bridge.py`
- `src/tests/test_chat_tool_bridge_contract.py`

## Verification

Local Windows verification:

```text
py -m pytest -q src\tests\test_chat_tool_bridge_contract.py src\tests\test_chat_tool_bridge_exports.py
17 passed in 0.08s

py -m pytest -q src\tests\test_tool_registry_contract.py src\tests\test_toolbench_deterministic_contract.py src\tests\test_tool_invocation_contract.py src\tests\test_tool_resolver_contract.py src\tests\test_tool_eligibility_gate_contract.py src\tests\test_tool_execution_harness_contract.py src\tests\test_tool_execution_audit_contract.py src\tests\test_tool_execution_audit_sink_contract.py src\tests\test_tool_execution_orchestrator_contract.py src\tests\test_tool_execution_orchestrator_exports.py src\tests\test_tool_request_adapter_contract.py src\tests\test_tool_request_adapter_exports.py src\tests\test_tool_use_presentation_contract.py src\tests\test_tool_use_presentation_exports.py src\tests\test_tool_foundation_consolidation_gate.py src\tests\test_chat_tool_bridge_contract.py src\tests\test_chat_tool_bridge_exports.py
222 passed in 0.47s
```

Packaging boundary:

```text
git diff --name-only -- SerapeumAI_Portable.spec build_portable.ps1 build_portable.bat
# no output
```

## Non-scope preserved

- No ChatPage / ChatPanel edits
- No UI changes
- No autonomous router
- No LLM parser
- No tool execution changes
- No DB writes
- No audit persistence
- No dependency changes
- No packaging changes
- No Quality Upgrade work

## Risk

- Packaging risk: none
- Windows risk: low
- Rollback risk: low
- Architecture risk: low; this tightens a non-executing bridge contract
- Product risk: low; no visible product behavior is enabled