### PR TITLE
Fix mounted chat project authority cleanup

### DIFF
--- a/src/ui/components/chat_llm_bridge.py
+++ b/src/ui/components/chat_llm_bridge.py
@@ -1,4 +1,4 @@
-import sqlite3
+﻿import sqlite3
 import logging
 from typing import Dict, Any, List, Optional
 from src.infra.adapters.cancellation import CancellationToken
@@ -37,7 +37,17 @@ class ChatLLMBridge:
 
         if hasattr(self.panel, 'orchestrator') and self.panel.orchestrator:
             self.panel._update_status("Agentic Reasoning...")
-            result = self.panel.orchestrator.answer_question(query=user_query, cancellation_token=token)
+            project_id = getattr(self.panel, "project_id", None)
+            if not project_id:
+                self.panel._append("System", "No active project is loaded for this chat.")
+                return
+
+            result = self.panel.orchestrator.answer_question(
+                query=user_query,
+                project_id=project_id,
+                snapshot_id=None,
+                cancellation_token=token,
+            )
 
             if isinstance(result, dict) and result.get("answer"):
                 # Handle Diagnostic Thinking Stream
@@ -70,3 +80,4 @@ class ChatLLMBridge:
                         pass
         else:
             self.panel._append("System", "Agent Orchestrator not initialized.")
+


### PR DESCRIPTION
## Summary

Closes #96.

This PR completes Upgrade 2B by removing the retained legacy chat authority risk where `ChatLLMBridge` could call `AgentOrchestrator.answer_question(...)` without explicit project context.

## Changes

- `src/ui/components/chat_llm_bridge.py`
  - Reads `project_id` from the chat panel before orchestrator use.
  - Returns a clean system message when no active project is loaded.
  - Calls `answer_question(...)` with explicit `project_id`, `snapshot_id=None`, and the existing cancellation token.

## Non-scope

- No packaging changes.
- No dependency changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No tool execution bridge.
- No LLM tool parser.
- No MCP/autonomous loop.
- No audit persistence.
- No snapshot implementation.
- No sourced-answer policy change.

## Verification

Owner-run Windows PowerShell proof:

```text
python -m pytest -q src/tests/test_mounted_chat_wiring.py src/tests/test_chat_project_isolation.py
...........                                                                                                      [100%]
11 passed in 0.29s
```

Production source scan:

```text
[PASS] no production answer_question calls without project_id found
```

## Risk

- Packaging risk: none.
- Windows risk: low.
- Rollback risk: low.
- Architecture risk: low; this only closes a retained legacy authority path.
- Product risk: reduced; retained chat paths now require explicit project context.

## Follow-up

Next backlog item after merge:

```text
Upgrade 2C — Sourced Answer Policy Freeze
```