### PR TITLE
Label support-only sourced answers

### DIFF
--- a/src/application/services/chat_answer_presentation.py
+++ b/src/application/services/chat_answer_presentation.py
@@ -301,9 +301,43 @@ def _select_ai_items(ai_lane: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
 
-def _build_source_basis_banner(*, trusted_items: List[Dict[str, Any]], extracted_items: List[Dict[str, Any]], linked_items: List[Dict[str, Any]], ai_items: List[Dict[str, Any]]) -> str:
+def _join_source_parts(parts: List[str]) -> str:
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    if len(parts) == 2:
+        return f"{parts[0]} + {parts[1]}"
+    return ", ".join(parts[:-1]) + f" + {parts[-1]}"
+
+
+def _build_support_only_notice(*, extracted_items: List[Dict[str, Any]], linked_items: List[Dict[str, Any]], ai_items: List[Dict[str, Any]]) -> str:
     parts: List[str] = []
-    if any(not item.get("is_group_heading") for item in trusted_items):
+    if extracted_items:
+        parts.append("extracted project evidence")
+    if linked_items:
+        parts.append("linked project support")
+    if ai_items:
+        parts.append("AI-generated non-governing synthesis")
+    joined = _join_source_parts(parts)
+    if not joined:
+        return ""
+    return f"Support-only answer — based on {joined}, not yet certified as trusted fact."
+
+
+def _build_source_basis_banner(*, trusted_items: List[Dict[str, Any]], extracted_items: List[Dict[str, Any]], linked_items: List[Dict[str, Any]], ai_items: List[Dict[str, Any]]) -> str:
+    has_trusted = any(not item.get("is_group_heading") for item in trusted_items)
+    if not has_trusted:
+        support_notice = _build_support_only_notice(
+            extracted_items=extracted_items,
+            linked_items=linked_items,
+            ai_items=ai_items,
+        )
+        if support_notice:
+            return support_notice
+
+    parts: List[str] = []
+    if has_trusted:
         parts.append("trusted facts")
     if extracted_items:
         parts.append("extracted evidence")
@@ -313,13 +347,7 @@ def _build_source_basis_banner(*, trusted_items: List[Dict[str, Any]], extracted
         parts.append("AI synthesis")
     if not parts:
         return "No grounded project material found."
-    if len(parts) == 1:
-        joined = parts[0]
-    elif len(parts) == 2:
-        joined = f"{parts[0]} + {parts[1]}"
-    else:
-        joined = ", ".join(parts[:-1]) + f" + {parts[-1]}"
-    return f"Based on {joined}."
+    return f"Based on {_join_source_parts(parts)}."
 
 def _first_ai_synthesis(ai_items: List[Dict[str, Any]]) -> str:
     for item in ai_items:
@@ -633,18 +661,28 @@ def build_answer_presentation(
         ai_items=ai_items,
     )
 
+    support_only_notice = ""
+    if not any(not item.get("is_group_heading") for item in trusted_items):
+        support_only_notice = _build_support_only_notice(
+            extracted_items=extracted_items,
+            linked_items=linked_items,
+            ai_items=ai_items,
+        )
+
+    main_answer_text = summary["text"]
+    if support_only_notice and not main_answer_text.startswith("Support-only answer"):
+        main_answer_text = f"{support_only_notice}\n\n{main_answer_text}"
+
     summary_block = {
         "title": "Direct Answer",
         "source_label": summary["source"],
-        "text": summary["text"],
+        "text": main_answer_text,
         "source_basis_banner": source_basis_banner,
     }
 
-    main_answer_text = summary["text"]
-
     copy_lines = [
         "## Direct Answer",
-        summary["text"],
+        main_answer_text,
     ]
     for section in sections:
         if not section.get("items") and not section.get("empty_message"):

--- a/src/tests/test_multi_lane_answer_path.py
+++ b/src/tests/test_multi_lane_answer_path.py
@@ -90,6 +90,8 @@ def test_answer_includes_trusted_facts_section_when_trusted_document_facts_exist
     orchestrator = AgentOrchestrator(db=lane_db, llm=MockLLM())
     result = orchestrator.answer_question(query="provide project scope summary", project_id="proj1")
     assert result["mode"] == "answered"
+    assert "Support-only answer" not in result["answer"]
+    assert result["answer_presentation"]["summary_block"]["source_label"] == "Trusted Facts"
     assert "## Trusted Facts" not in result["answer"]
     assert "generator room ventilation" in result["answer"].lower()
     assert "## Trusted Facts" in result["answer_presentation"]["details_copy_text"]
@@ -101,9 +103,13 @@ def test_answer_uses_extracted_evidence_when_trusted_facts_are_missing(lane_db):
     orchestrator = AgentOrchestrator(db=lane_db, llm=MockLLM())
     result = orchestrator.answer_question(query="scope", project_id="proj1")
     assert result["mode"] == "answered"
+    assert "Support-only answer" in result["answer"]
+    assert "not yet certified as trusted fact" in result["answer"]
+    assert result["answer_presentation"]["source_basis_banner"].startswith("Support-only answer")
     assert "## Trusted Facts" not in result["answer"]
     assert "generator room" in result["answer"].lower()
     assert "No trusted facts found for this question." in result["answer_presentation"]["details_copy_text"]
+    assert "## Direct Answer\nSupport-only answer" in result["answer_presentation"]["details_copy_text"]
     assert "## Extracted Evidence" in result["answer_presentation"]["details_copy_text"]
 
 
@@ -112,6 +118,9 @@ def test_answer_labels_ai_generated_synthesis_as_non_governing(lane_db):
     orchestrator = AgentOrchestrator(db=lane_db, llm=MockLLM())
     result = orchestrator.answer_question(query="provide project scope summary", project_id="proj1")
     assert result["mode"] == "answered"
+    assert "Support-only answer" in result["answer"]
+    assert "not yet certified as trusted fact" in result["answer"]
+    assert "AI-generated non-governing synthesis" in result["answer_presentation"]["source_basis_banner"]
     assert "generator room ventilation" in result["answer"].lower()
     assert "## AI-Generated Synthesis" in result["answer_presentation"]["details_copy_text"]
     assert "non-governing" in result["answer_presentation"]["details_copy_text"]


### PR DESCRIPTION
## Summary

Closes #99.

Implements the #98 frozen doctrine: Option B — sourced multi-lane chat with strict authority labeling.

Support-only answers now visibly carry not-certified / non-governing authority language in the main answer surface, not only behind Show Evidence.

## Changes

- `src/application/services/chat_answer_presentation.py`
  - Adds source-part joining helper.
  - Adds support-only notice builder.
  - Strengthens `source_basis_banner` for answers without trusted facts.
  - Prefixes support-only direct answers with a visible support-only notice.
  - Preserves the same support-only notice in copy/details text.

- `src/tests/test_multi_lane_answer_path.py`
  - Proves trusted-fact answers are not mislabeled support-only.
  - Proves extracted-evidence-only answers visibly say support-only / not certified.
  - Proves AI-supported answers carry non-governing support-only wording.

## Non-scope

- No packaging changes.
- No dependency changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM tool parser.
- No MCP/autonomous loop.
- No audit persistence.
- No snapshot implementation.
- No broad UI redesign.
- No Document Center/File Inspector work.
- No schedule workspace implementation.
- No Revit bridge work.

## Verification

Owner-run Windows PowerShell proof:

```text
python -m pytest -q src/tests/test_multi_lane_answer_path.py src/tests/test_truth_state_enforcement.py src/tests/test_mounted_chat_wiring.py src/tests/test_chat_project_isolation.py
......................                                                                                           [100%]
22 passed in 0.74s
```

Changed files:

```text
src/application/services/chat_answer_presentation.py
src/tests/test_multi_lane_answer_path.py
```

Final local status:

```text
git status --short
# clean
```

## Risk

- Packaging risk: none.
- Windows risk: low.
- Rollback risk: medium because visible answer wording changes.
- Architecture risk: reduced by making support-only authority explicit.
- Product risk: reduced because support-only answers can no longer look like certified truth.

## Follow-up

Next backlog item after merge:

```text
Upgrade 2E — Snapshot/State Wording Honesty Patch
```