### PR TITLE
Clarify snapshot state wording honesty

### DIFF
--- a/src/tests/test_snapshot_state_wording_honesty.py
+++ b/src/tests/test_snapshot_state_wording_honesty.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def test_mounted_snapshot_wording_is_informational_only():
+    source = Path("src/ui/main_window.py").read_text(encoding="utf-8-sig")
+
+    assert "Informational only - does not change chat, facts, or answer authority yet." in source
+    assert "snapshot_id=None" in Path("src/application/services/mounted_chat_runtime.py").read_text(encoding="utf-8-sig")
+
+
+def test_facts_page_does_not_claim_selected_project_state_governs():
+    source = Path("src/ui/pages/facts_page.py").read_text(encoding="utf-8-sig")
+
+    forbidden_phrases = [
+        "selected project state",
+        "selected snapshot",
+        "as-of answer state",
+    ]
+    lowered = source.lower()
+    for phrase in forbidden_phrases:
+        assert phrase not in lowered
+
+    assert "current project fact set" in source
+    assert "does not change fact or chat authority yet" in source

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -227,7 +227,7 @@ class MainApp(ctk.CTk):
 
         self.lbl_snapshot_hint = tk.Label(
             self.frame_sidebar,
-            text="Informational only - does not change chat or facts yet.",
+            text="Informational only - does not change chat, facts, or answer authority yet.",
             anchor="w",
             justify="left",
             wraplength=self.sidebar_width - 40,
@@ -319,7 +319,7 @@ class MainApp(ctk.CTk):
         self.show_page("dashboard")
 
     def _on_snapshot_change(self, value):
-        # Packet A contract: mounted selector is intentionally non-authoritative
+        # Packet A contract: mounted selector is intentionally informational and non-authoritative
         # until selected state is fully propagated into mounted answer/facts paths.
         logger.info("[MainApp] Ignoring imported-date selector change (informational only): %s", value)
 
@@ -604,7 +604,7 @@ class MainApp(ctk.CTk):
             self.btn_close.pack(pady=5, padx=20, fill="x")
 
             # Packet A contract: keep imported dates visible as informational
-            # project timeline context only. They do not select answer state yet.
+            # project timeline context only. They do not select chat, fact, or answer authority yet.
             try:
                 dates = self.db.execute(
                     "SELECT DISTINCT date(imported_at, 'unixepoch') "

--- a/src/ui/pages/facts_page.py
+++ b/src/ui/pages/facts_page.py
@@ -33,7 +33,7 @@ class FactsPage(BasePage):
 
         self.lbl_scope = tk.Label(
             self.frame_header,
-            text="Review stored facts for the selected project state. Select a fact to inspect its meaning, provenance, and approval state.",
+            text="Review facts stored for the current project fact set. The imported-date selector is informational only and does not change fact or chat authority yet. Select a fact to inspect its meaning, provenance, and approval state.",
             font=Theme.FONT_BODY,
             fg=Theme.TEXT_MUTED,
             bg=Theme.BG_DARKEST,
@@ -66,9 +66,9 @@ class FactsPage(BasePage):
         snapshot_id, snapshot_label = self._get_snapshot_context()
 
         if snapshot_label:
-            self.lbl_scope.configure(text=f"Review facts stored for: {snapshot_label}. Select a fact to inspect meaning, provenance, and approval state.")
+            self.lbl_scope.configure(text=f"Review facts shown for the current project fact set. Display context: {snapshot_label}. Select a fact to inspect meaning, provenance, and approval state.")
         else:
-            self.lbl_scope.configure(text="Review stored facts for the selected project state. Select a fact to inspect its meaning, provenance, and approval state.")
+            self.lbl_scope.configure(text="Review facts stored for the current project fact set. The imported-date selector is informational only and does not change fact or chat authority yet. Select a fact to inspect its meaning, provenance, and approval state.")
 
         self.tbl_facts.load_facts(snapshot_id=snapshot_id)
 


### PR DESCRIPTION
## Summary

Closes #101.

This PR completes Upgrade 2E by tightening visible snapshot/state wording so the mounted imported-date selector is clearly informational only and does not imply chat, facts, or answer-authority governance.

## Changes

- `src/ui/main_window.py`
  - Clarifies sidebar imported-date selector wording: it does not change chat, facts, or answer authority yet.
  - Updates internal comments to call the selector informational and non-authoritative.

- `src/ui/pages/facts_page.py`
  - Replaces “selected project state” wording with “current project fact set.”
  - Clarifies that imported-date context is informational only and does not change fact or chat authority yet.

- `src/tests/test_snapshot_state_wording_honesty.py`
  - Adds focused source/wording tests proving the mounted wording is informational only.
  - Proves Facts page no longer claims selected-state/snapshot/as-of answer governance.
  - Proves mounted chat runtime still uses `snapshot_id=None`.

## Non-scope

- No snapshot binding implementation.
- No fact snapshot filtering changes.
- No chat snapshot propagation.
- No schema changes.
- No packaging changes.
- No dependency changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM parser.
- No MCP/autonomous loop.
- No audit persistence.
- No broad UI redesign.
- No Document Center/File Inspector work.
- No schedule workspace implementation.
- No Revit bridge work.

## Verification

Owner-run Windows PowerShell proof:

```text
python -m pytest -q src/tests/test_snapshot_state_wording_honesty.py src/tests/test_mounted_chat_wiring.py src/tests/test_chat_project_isolation.py src/tests/test_multi_lane_answer_path.py src/tests/test_truth_state_enforcement.py
........................                                                                                         [100%]
24 passed in 0.92s
```

Changed files:

```text
src/ui/main_window.py
src/ui/pages/facts_page.py
src/tests/test_snapshot_state_wording_honesty.py
```

Final local status:

```text
git status --short
# clean
```

## Risk

- Packaging risk: none.
- Windows risk: low.
- Rollback risk: low.
- Architecture risk: low; wording/test-only patch.
- Product risk: reduced because UI no longer overclaims snapshot/state authority.

## Follow-up

Next backlog item after merge:

```text
Upgrade 2F — Cross-Project Runtime Isolation Proof
```