### PR TITLE
Fix extractor reachability and evidence hygiene

### DIFF
--- a/src/application/jobs/extract_job.py
+++ b/src/application/jobs/extract_job.py
@@ -11,6 +11,9 @@ from src.engine.extractors.ifc_extractor import IFCExtractor
 from src.engine.extractors.register_extractor import ExcelRegisterExtractor
 from src.engine.extractors.pdf_extractor import UniversalPdfExtractor
 from src.engine.extractors.field_extractor import FieldExtractor
+from src.engine.extractors.word_extractor import WordExtractor
+from src.engine.extractors.pptx_extractor import PPTXExtractor
+from src.engine.extractors.dgn_extractor import DGNExtractor
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +37,10 @@ class ExtractJob(Job):
         "ifc": IFCExtractor,
         "excel_register": ExcelRegisterExtractor,
         "pdf": UniversalPdfExtractor,
-        "field": FieldExtractor
+        "field": FieldExtractor,
+        "word": WordExtractor,
+        "pptx": PPTXExtractor,
+        "dgn": DGNExtractor,
     }
 
     # ... (existing code for init/to_dict/from_dict) ...
@@ -245,6 +251,61 @@ class ExtractJob(Job):
              db.execute("INSERT OR REPLACE INTO ifc_projects (global_id, file_version_id, name) VALUES (?, ?, ?)", (data["GlobalId"], vid, data["Name"]))
         elif rtype == "ifc_spatial":
              db.execute("INSERT OR REPLACE INTO ifc_spatial_structure (element_id, file_version_id, entity_type, name) VALUES (?, ?, ?, ?)", (data["GlobalId"], vid, data["EntityType"], data["Name"]))
+        elif rtype == "ifc_element_metadata":
+             element_id = data.get("ElementId")
+             if not element_id:
+                 logger.warning("[ExtractJob] Skipping IFC element metadata without ElementId: %s", data)
+                 return
+             existing = db.execute(
+                 "SELECT raw_properties_json FROM ifc_elements WHERE element_id=? AND file_version_id=?",
+                 (element_id, vid),
+             ).fetchone()
+             raw_properties = {}
+             if existing and existing["raw_properties_json"]:
+                 try:
+                     raw_properties = json.loads(existing["raw_properties_json"]) or {}
+                 except Exception:
+                     raw_properties = {"_previous_raw": existing["raw_properties_json"]}
+             pset_name = data.get("PSetName") or "Properties"
+             raw_properties[pset_name] = {
+                 "properties": data.get("Properties", {}),
+                 "is_quantity": data.get("IsQuantity", False),
+             }
+             db.execute(
+                 "INSERT OR REPLACE INTO ifc_elements (element_id, file_version_id, spatial_container_id, entity_type, name, tag, raw_properties_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                 (
+                     element_id,
+                     vid,
+                     data.get("SpatialContainerId"),
+                     data.get("EntityType"),
+                     data.get("Name") or data.get("PSetName"),
+                     data.get("Tag"),
+                     json.dumps(raw_properties),
+                 ),
+             )
+        elif rtype == "ifc_connection":
+             element1 = data.get("Element1Id")
+             element2 = data.get("Element2Id")
+             if not element1 or not element2:
+                 logger.warning("[ExtractJob] Skipping IFC connection without both endpoint ids: %s", data)
+                 return
+             link_id = f"ifc_conn_{vid}_{element1}_{element2}"
+             db.execute(
+                 "INSERT OR REPLACE INTO links (link_id, project_id, link_type, from_kind, from_id, to_kind, to_id, status, confidence, method_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                 (
+                     link_id,
+                     self.project_id,
+                     "ifc.connection",
+                     "ifc_element",
+                     element1,
+                     "ifc_element",
+                     element2,
+                     "CANDIDATE",
+                     1.0,
+                     "ifc_extractor_v1",
+                     db._ts(),
+                 ),
+             )
              
         # Register Logic
         elif rtype == "register_row":

--- a/src/engine/extractors/register_extractor.py
+++ b/src/engine/extractors/register_extractor.py
@@ -75,55 +75,57 @@ class ExcelRegisterExtractor(BaseExtractor):
         diagnostics = []
         
         
-        with open("D:\\SerapeumAI\\extractor_debug.txt", "a", encoding="utf-8") as dbg:
-            dbg.write(f"\n--- Extracting {file_path} ---\n")
-            try:
-                # Load all sheets
-                xls = pd.read_excel(file_path, sheet_name=None, dtype=str)
-                dbg.write(f"Sheets found: {list(xls.keys())}\n")
-                
-                for sheet_name in xls.keys():
-                    # Read first 30 rows to sniff header
-                    df_peek = pd.read_excel(file_path, sheet_name=sheet_name, nrows=30, header=None, dtype=str)
-                    header_row_idx = self._detect_header_row(df_peek)
-                    
-                    dbg.write(f"Sheet {sheet_name}: Detected Header at Row {header_row_idx}\n")
-                    
-                    # Read full sheet with correct header
-                    # If header_row_idx is None, assume 0 or empty sheet
-                    start_row = header_row_idx if header_row_idx is not None else 0
-                    df = pd.read_excel(file_path, sheet_name=sheet_name, header=start_row, dtype=str)
-                    
-                    if header_row_idx is None and len(df) < 2:
-                         dbg.write(f"Sheet {sheet_name}: Empty or unstructured, skipping.\n")
-                         continue
+        try:
+            # Load all sheets once, then inspect each sheet header before full extraction.
+            # Diagnostics are kept in-memory and through logger only; no debug file is written.
+            xls = pd.read_excel(file_path, sheet_name=None, dtype=str)
+            diagnostics.append(f"Sheets found: {list(xls.keys())}")
+            logger.debug("Excel register sheets found in %s: %s", file_path, list(xls.keys()))
 
-                    # Clean keys
-                    df.columns = [str(c).strip() for c in df.columns]
-                    
-                    # Iterate rows
-                    for idx, row in df.iterrows():
-                        # Remove NaNs / Nones
-                        row_data = {k: v for k, v in row.to_dict().items() if pd.notna(v) and str(v) != "nan" and v != ""}
-                        
-                        if not row_data:
-                            continue # Skip empty rows
-                            
-                        records.append({
-                            "type": "register_row",
-                            "data": {
-                                "sheet_name": sheet_name,
-                                "row_index": idx + start_row + 1, # Adjust for skip
-                                "content": row_data
-                            },
-                            "provenance": {"sheet": sheet_name, "row": idx + start_row + 1}
-                        })
-                dbg.write(f"Total records: {len(records)}\n")
-                return ExtractionResult(records=records, diagnostics=diagnostics, success=True)
-                
-            except Exception as e:
-                dbg.write(f"ERROR: {e}\n")
-                logger.error(f"Excel Extraction failed: {e}")
-                import traceback
-                dbg.write(traceback.format_exc())
-                return ExtractionResult(success=False, diagnostics=[str(e)])
+            for sheet_name in xls.keys():
+                # Read first 30 rows to sniff header.
+                df_peek = pd.read_excel(file_path, sheet_name=sheet_name, nrows=30, header=None, dtype=str)
+                header_row_idx = self._detect_header_row(df_peek)
+                diagnostics.append(f"Sheet {sheet_name}: detected header row {header_row_idx}")
+                logger.debug("Excel register sheet %s detected header row %s", sheet_name, header_row_idx)
+
+                start_row = header_row_idx if header_row_idx is not None else 0
+                df = pd.read_excel(file_path, sheet_name=sheet_name, header=start_row, dtype=str)
+
+                if header_row_idx is None and len(df) < 2:
+                    diagnostics.append(f"Sheet {sheet_name}: empty or unstructured, skipped")
+                    continue
+
+                # Clean keys.
+                df.columns = [str(c).strip() for c in df.columns]
+
+                # Iterate rows.
+                for idx, row in df.iterrows():
+                    row_data = {
+                        k: v
+                        for k, v in row.to_dict().items()
+                        if pd.notna(v) and str(v) != "nan" and v != ""
+                    }
+
+                    if not row_data:
+                        continue
+
+                    records.append({
+                        "type": "register_row",
+                        "data": {
+                            "sheet_name": sheet_name,
+                            "row_index": idx + start_row + 1,
+                            "content": row_data
+                        },
+                        "provenance": {"sheet": sheet_name, "row": idx + start_row + 1}
+                    })
+
+            diagnostics.append(f"Total register rows extracted: {len(records)}")
+            return ExtractionResult(records=records, diagnostics=diagnostics, success=True)
+
+        except Exception as e:
+            logger.error(f"Excel Extraction failed: {e}")
+            import traceback
+            diagnostics.append(str(e))
+            diagnostics.append(traceback.format_exc())
+            return ExtractionResult(success=False, diagnostics=diagnostics)

--- a/src/tests/test_excel_register_extractor_hygiene.py
+++ b/src/tests/test_excel_register_extractor_hygiene.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+
+def test_excel_register_extractor_does_not_write_absolute_debug_file():
+    source = Path("src/engine/extractors/register_extractor.py").read_text(encoding="utf-8-sig")
+
+    assert "D:\\SerapeumAI\\extractor_debug.txt" not in source
+    assert "extractor_debug.txt" not in source
+    assert "with open(" not in source
+    assert "diagnostics.append" in source
+    assert "logger.debug" in source

--- a/src/tests/test_extractor_registry_reachability.py
+++ b/src/tests/test_extractor_registry_reachability.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from src.application.jobs.extract_job import ExtractJob
+from src.engine.extractors.dgn_extractor import DGNExtractor
+from src.engine.extractors.pptx_extractor import PPTXExtractor
+from src.engine.extractors.word_extractor import WordExtractor
+
+
+def test_extract_job_registry_includes_existing_reachable_document_extractors():
+    assert ExtractJob.EXTRACTORS["word"] is WordExtractor
+    assert ExtractJob.EXTRACTORS["pptx"] is PPTXExtractor
+    assert ExtractJob.EXTRACTORS["dgn"] is DGNExtractor
+
+
+def test_extract_job_registry_keeps_existing_evidence_extractors():
+    expected = {"p6", "ifc", "excel_register", "pdf", "field", "word", "pptx", "dgn"}
+    assert expected.issubset(set(ExtractJob.EXTRACTORS))

--- a/src/tests/test_ifc_extractor_persistence_contract.py
+++ b/src/tests/test_ifc_extractor_persistence_contract.py
@@ -1,0 +1,89 @@
+﻿# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from src.application.jobs.extract_job import ExtractJob
+from src.infra.persistence.database_manager import DatabaseManager
+
+
+def _build_db(tmp_path):
+    db = DatabaseManager(root_dir=str(tmp_path), db_name=":memory:")
+    migration = Path("src/infra/persistence/migrations/001_baseline_v14.sql")
+    db.execute_script(migration.read_text(encoding="utf-8-sig"))
+
+    now = db._ts()
+    source_path = str(tmp_path / "model.ifc")
+
+    db.execute(
+        "INSERT INTO file_registry (file_id, project_id, first_seen_path, created_at) VALUES (?, ?, ?, ?)",
+        ("file_ifc", "ProjectA", source_path, now),
+    )
+    db.execute(
+        "INSERT INTO file_versions (file_version_id, file_id, sha256, size_bytes, file_ext, imported_at, source_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("fv_ifc", "file_ifc", "hash-ifc", 1, ".ifc", now, source_path),
+    )
+    db.commit()
+
+    return db
+
+
+def test_ifc_element_metadata_records_are_persisted_to_ifc_elements(tmp_path):
+    db = _build_db(tmp_path)
+    job = ExtractJob("job_ifc", "ProjectA", "fv_ifc", extractor_name="ifc")
+
+    job._insert_record(
+        db,
+        {
+            "type": "ifc_element_metadata",
+            "data": {
+                "EntityType": "IfcWall",
+                "ElementId": "wall-guid-001",
+                "PSetName": "Pset_WallCommon",
+                "Properties": {"FireRating": "2HR"},
+                "IsQuantity": False,
+            },
+            "provenance": {"entity": "IfcWall", "pset": "Pset_WallCommon"},
+        },
+        doc_id="doc_ifc",
+    )
+
+    row = db.execute(
+        "SELECT element_id, entity_type, raw_properties_json FROM ifc_elements WHERE element_id=?",
+        ("wall-guid-001",),
+    ).fetchone()
+
+    assert row is not None
+    assert row["entity_type"] == "IfcWall"
+    assert "Pset_WallCommon" in row["raw_properties_json"]
+    assert "FireRating" in row["raw_properties_json"]
+
+
+def test_ifc_connection_records_are_persisted_to_links(tmp_path):
+    db = _build_db(tmp_path)
+    job = ExtractJob("job_ifc", "ProjectA", "fv_ifc", extractor_name="ifc")
+
+    job._insert_record(
+        db,
+        {
+            "type": "ifc_connection",
+            "data": {
+                "RelType": "Connectivity",
+                "Element1Id": "wall-guid-001",
+                "Element2Id": "slab-guid-002",
+            },
+            "provenance": {"entity": "IfcRelConnectsElements"},
+        },
+        doc_id="doc_ifc",
+    )
+
+    row = db.execute(
+        "SELECT project_id, link_type, from_kind, from_id, to_kind, to_id, status FROM links WHERE link_type=?",
+        ("ifc.connection",),
+    ).fetchone()
+
+    assert row is not None
+    assert row["project_id"] == "ProjectA"
+    assert row["from_kind"] == "ifc_element"
+    assert row["from_id"] == "wall-guid-001"
+    assert row["to_kind"] == "ifc_element"
+    assert row["to_id"] == "slab-guid-002"
+    assert row["status"] == "CANDIDATE"


### PR DESCRIPTION
## Summary

Closes #106.

Completes Upgrade 3B by fixing the low-risk, high-trust evidence hygiene gaps identified by #105.

## Changes

- `src/application/jobs/extract_job.py`
  - Registers existing document/CAD extractor classes in `ExtractJob.EXTRACTORS`:
    - `word`
    - `pptx`
    - `dgn`
  - Persists IFC `ifc_element_metadata` records into `ifc_elements` instead of silently dropping them.
  - Persists IFC `ifc_connection` records into `links` as candidate IFC connection links.

- `src/engine/extractors/register_extractor.py`
  - Removes the absolute debug side effect path:
    - `D:\SerapeumAI\extractor_debug.txt`
  - Replaces file debug writes with in-memory diagnostics and logger debug calls.

- `src/tests/test_extractor_registry_reachability.py`
  - Proves the extractor registry includes the existing Word, PPTX, and DGN extractors.
  - Proves existing evidence extractors remain registered.

- `src/tests/test_ifc_extractor_persistence_contract.py`
  - Proves IFC element metadata is persisted to `ifc_elements`.
  - Proves IFC connections are persisted to `links` as candidate IFC connection records.
  - Seeds `file_registry` / `file_versions` so SQLite foreign-key constraints are respected.

- `src/tests/test_excel_register_extractor_hygiene.py`
  - Proves the Excel register extractor no longer writes to an absolute debug path.

## Non-scope

- No packaging changes.
- No dependency changes.
- No OCR dependency additions.
- No IFC/P6 parser dependency additions.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM parser.
- No MCP/autonomous loop.
- No audit persistence implementation.
- No snapshot implementation.
- No broad UI redesign.
- No Document Center redesign.
- No Schedule Truth Workspace implementation.
- No Revit bridge work.

## Verification

Owner-run Windows PowerShell proof after amended fixture:

```text
python -m pytest -q `
  src/tests/test_extractor_registry_reachability.py `
  src/tests/test_ifc_extractor_persistence_contract.py `
  src/tests/test_excel_register_extractor_hygiene.py `
  src/tests/test_file_inspector_evidence_lanes.py `
  src/tests/test_file_inspector_source.py `
  src/tests/test_p6_truth.py `
  src/tests/test_retrieval_project_isolation.py `
  src/tests/test_mounted_chat_wiring.py `
  src/tests/test_multi_lane_answer_path.py `
  src/tests/test_truth_state_enforcement.py `
  src/tests/test_snapshot_state_wording_honesty.py
..................................                                                                               [100%]
34 passed, 5 warnings in 0.99s
```

Scope check:

```text
[PASS] Changed files are within #106 scope.
```

Final local status:

```text
git status --short
# clean
```

Branch head after amend/force-push:

```text
18a4a62 Fix extractor reachability and evidence hygiene
```

## Risk

- Packaging risk: low; no packaging files or dependencies changed.
- Windows risk: reduced by removing absolute debug-path writing.
- Rollback risk: medium because extractor registry reachability changes.
- Architecture risk: reduced by making extractor reachability and IFC emitted-record handling explicit.
- Product risk: reduced by eliminating silent evidence capability drift.

## Follow-up

Next likely packet after merge:

```text
Upgrade 3C — PDF Metadata Completeness Contract
```