### PR TITLE
Add PDF metadata completeness contract

### DIFF
--- a/src/engine/extractors/pdf_extractor.py
+++ b/src/engine/extractors/pdf_extractor.py
@@ -49,6 +49,13 @@ class UniversalPdfExtractor(BaseExtractor):
             
             full_text = ""
             page_texts = {}
+            page_composition_counts = {
+                "empty": 0,
+                "vector": 0,
+                "scanned": 0,
+                "combined": 0,
+            }
+            pdf_document_metadata = self._extract_document_metadata(reader, doc)
             
             # Phase 1.1 Structural PDF Metadata Router
             update_stage("ROUTING_EXTRACTION", f"Processing {len(reader.pages)} pages dynamically")
@@ -59,6 +66,7 @@ class UniversalPdfExtractor(BaseExtractor):
                 
                 # 1. Sniff composition
                 composition = self._sniff_composition(p_pypdf, p_fitz)
+                page_composition_counts[composition] = page_composition_counts.get(composition, 0) + 1
                 
                 # 2. Route to appropriate handler
                 text = ""
@@ -132,16 +140,66 @@ class UniversalPdfExtractor(BaseExtractor):
             # 4. Compile Metrics
             metadata = {
                 "page_count": len(reader.pages),
+                "pdf_page_count": len(reader.pages),
                 "char_count": len(full_text),
                 "block_count": len(blocks),
-                "image_count": sum(len(p.images) for p in reader.pages)
+                "image_count": sum(len(p.images) for p in reader.pages),
+                "page_composition_counts": page_composition_counts,
             }
+            metadata.update(pdf_document_metadata)
             
             return ExtractionResult(records=records, diagnostics=diagnostics, metadata=metadata, success=True)
             
         except Exception as e:
             logger.error(f"PDF Extraction failed: {e}")
             return ExtractionResult(success=False, diagnostics=[str(e)])
+
+    def _extract_document_metadata(self, reader, doc) -> Dict[str, Any]:
+        """
+        Extract normalized PDF document metadata using the already-open pypdf
+        reader and PyMuPDF document.
+
+        This is metadata capture only. It does not change page routing, OCR,
+        VLM behavior, or deterministic extraction records.
+        """
+        raw_metadata: Dict[str, Any] = {}
+
+        pypdf_meta = getattr(reader, "metadata", None) or {}
+        try:
+            for key, value in pypdf_meta.items():
+                if value not in (None, ""):
+                    raw_metadata[str(key)] = str(value)
+        except Exception:
+            raw_metadata = {}
+
+        fitz_meta: Dict[str, Any] = {}
+        try:
+            fitz_raw = getattr(doc, "metadata", None) or {}
+            fitz_meta = {str(k): str(v) for k, v in fitz_raw.items() if v not in (None, "")}
+        except Exception:
+            fitz_meta = {}
+
+        def first(*keys: str) -> Optional[str]:
+            for key in keys:
+                if key in raw_metadata and raw_metadata[key] not in (None, ""):
+                    return str(raw_metadata[key])
+                if key in fitz_meta and fitz_meta[key] not in (None, ""):
+                    return str(fitz_meta[key])
+            return None
+
+        return {
+            "pdf_producer": first("/Producer", "producer"),
+            "pdf_creator": first("/Creator", "creator"),
+            "pdf_author": first("/Author", "author"),
+            "pdf_title": first("/Title", "title"),
+            "pdf_subject": first("/Subject", "subject"),
+            "pdf_creation_date": first("/CreationDate", "creationDate", "creation_date"),
+            "pdf_modified_date": first("/ModDate", "modDate", "mod_date"),
+            "pdf_raw_metadata": {
+                "pypdf": raw_metadata,
+                "pymupdf": fitz_meta,
+            },
+        }
 
     def _classify_document(self, file_path: str, text: str) -> str:
         text_lower = text.lower()[:2000] # Check first 2000 chars

--- a/src/tests/test_pdf_metadata_completeness.py
+++ b/src/tests/test_pdf_metadata_completeness.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from pypdf import PdfReader, PdfWriter
+
+from src.engine.extractors.pdf_extractor import UniversalPdfExtractor
+
+
+def _write_metadata_pdf(path: Path) -> None:
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    writer.add_metadata(
+        {
+            "/Title": "Engineering Metadata Test",
+            "/Author": "Serapeum Test Author",
+            "/Subject": "PDF metadata contract",
+            "/Creator": "Serapeum Test Creator",
+            "/Producer": "Serapeum Test Producer",
+            "/CreationDate": "D:20260102030405+03'00'",
+            "/ModDate": "D:20260103040506+03'00'",
+        }
+    )
+    with path.open("wb") as fh:
+        writer.write(fh)
+
+
+def test_pdf_extractor_metadata_includes_normalized_document_info(tmp_path):
+    pdf_path = tmp_path / "metadata-contract.pdf"
+    _write_metadata_pdf(pdf_path)
+
+    result = UniversalPdfExtractor().extract(str(pdf_path))
+
+    assert result.success is True
+    metadata = result.metadata
+
+    assert metadata["pdf_title"] == "Engineering Metadata Test"
+    assert metadata["pdf_author"] == "Serapeum Test Author"
+    assert metadata["pdf_subject"] == "PDF metadata contract"
+    assert metadata["pdf_creator"] == "Serapeum Test Creator"
+    assert metadata["pdf_producer"] == "Serapeum Test Producer"
+    assert metadata["pdf_creation_date"] == "D:20260102030405+03'00'"
+    assert metadata["pdf_modified_date"] == "D:20260103040506+03'00'"
+    assert metadata["pdf_page_count"] == 1
+
+
+def test_pdf_extractor_preserves_raw_metadata_safely(tmp_path):
+    pdf_path = tmp_path / "raw-metadata.pdf"
+    _write_metadata_pdf(pdf_path)
+
+    metadata = UniversalPdfExtractor().extract(str(pdf_path)).metadata
+    raw = metadata["pdf_raw_metadata"]
+
+    assert set(raw) >= {"pypdf", "pymupdf"}
+    assert raw["pypdf"]["/Title"] == "Engineering Metadata Test"
+    assert raw["pypdf"]["/Creator"] == "Serapeum Test Creator"
+    assert isinstance(raw["pymupdf"], dict)
+
+
+def test_pdf_extractor_summarizes_page_composition_counts(tmp_path):
+    pdf_path = tmp_path / "blank-page.pdf"
+    _write_metadata_pdf(pdf_path)
+
+    result = UniversalPdfExtractor().extract(str(pdf_path))
+    counts = result.metadata["page_composition_counts"]
+
+    assert result.success is True
+    assert counts["empty"] == 1
+    assert counts["vector"] == 0
+    assert counts["scanned"] == 0
+    assert counts["combined"] == 0
+    assert sum(counts.values()) == result.metadata["pdf_page_count"]
+
+
+def test_pdf_extractor_keeps_existing_record_shapes(tmp_path):
+    pdf_path = tmp_path / "record-shapes.pdf"
+    _write_metadata_pdf(pdf_path)
+
+    result = UniversalPdfExtractor().extract(str(pdf_path))
+    record_types = [record["type"] for record in result.records]
+
+    assert "pdf_page" in record_types
+    assert "doc_classification" in record_types
+
+    page_record = next(record for record in result.records if record["type"] == "pdf_page")
+    assert set(page_record["data"]) >= {"page_no", "text_content", "metadata"}
+    assert set(page_record["provenance"]) >= {"page", "method", "composition"}
+
+
+def test_pdf_metadata_patch_does_not_enable_vlm_routing():
+    source = Path("src/engine/extractors/pdf_extractor.py").read_text(encoding="utf-8-sig")
+
+    assert "_extract_vlm(" in source
+    assert "self._extract_vlm(" not in source


### PR DESCRIPTION
## Summary

Closes #108.

Completes Upgrade 3C by making PDF extraction metadata more complete and testable without changing routing, OCR behavior, VLM behavior, packaging, or dependencies.

## Changes

- `src/engine/extractors/pdf_extractor.py`
  - Adds normalized PDF document metadata to `ExtractionResult.metadata`:
    - `pdf_producer`
    - `pdf_creator`
    - `pdf_author`
    - `pdf_title`
    - `pdf_subject`
    - `pdf_creation_date`
    - `pdf_modified_date`
    - `pdf_raw_metadata`
  - Adds `pdf_page_count` alongside the existing `page_count` field.
  - Adds document-level `page_composition_counts` for:
    - `empty`
    - `vector`
    - `scanned`
    - `combined`
  - Preserves existing `pdf_page`, `doc_classification`, and `doc_blocks` record shapes.

- `src/tests/test_pdf_metadata_completeness.py`
  - Proves normalized PDF metadata fields are populated from a lightweight generated PDF fixture.
  - Proves raw metadata is preserved safely.
  - Proves page composition counts summarize the document page classifications.
  - Proves existing record shapes remain compatible.
  - Proves this patch does not enable VLM routing.

## Non-scope

- No packaging changes.
- No dependency changes.
- No OCR dependency additions.
- No IFC/P6/parser dependency changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM parser.
- No MCP/autonomous loop.
- No audit persistence implementation.
- No snapshot implementation.
- No Document Center redesign.
- No Schedule Truth Workspace implementation.
- No Revit bridge work.
- No VLM routing change.
- No OCR routing rewrite.

## Verification

Owner-run Windows PowerShell proof after rebasing onto current `main` with PR #107 included:

```text
python -m pytest -q `
  src/tests/test_pdf_metadata_completeness.py `
  src/tests/test_file_inspector_evidence_lanes.py `
  src/tests/test_file_inspector_source.py `
  src/tests/test_extractor_registry_reachability.py `
  src/tests/test_excel_register_extractor_hygiene.py `
  src/tests/test_ifc_extractor_persistence_contract.py `
  src/tests/test_p6_truth.py
....................                                                                                             [100%]
20 passed, 5 warnings in 0.71s
```

Scope check:

```text
[PASS] Changed files are within #108 scope.
```

Final local status:

```text
git status --short
# clean
```

Branch head after rebase/amend/force-push:

```text
9c06c30 Add PDF metadata completeness contract
```

## Risk

- Packaging risk: low; no packaging files or dependencies changed.
- Windows risk: low.
- Rollback risk: low/medium because extractor metadata output changes.
- Architecture risk: reduced by making PDF metadata explicit and testable.
- Product risk: reduced because metadata visibility no longer depends only on opportunistic presentation-time reads.

## Follow-up

Next likely packet after merge:

```text
Upgrade 3D — PDF Routing Fixture Pack
```