### PR TITLE
Harden IFC dependency honesty contract

### DIFF
--- a/src/engine/extractors/ifc_extractor.py
+++ b/src/engine/extractors/ifc_extractor.py
@@ -9,10 +9,12 @@ logger = logging.getLogger(__name__)
 
 class IFCExtractor(BaseExtractor):
     """
-    Extracts data from IFC files (STEP format).
-    Strategy:
-    1. Try `import ifcopenshell` (Best).
-    2. Fallback to `Regex/Text` parsing for structure (Good enough for Phase 1).
+    Extracts deterministic engineering evidence from IFC files using the optional
+    `ifcopenshell` package.
+
+    There is no text/regex fallback in the current extractor. If `ifcopenshell`
+    is unavailable, extraction fails honestly with diagnostics and emits no
+    records.
     """
     
     @property
@@ -111,9 +113,13 @@ class IFCExtractor(BaseExtractor):
             diagnostics.append(f"Successfully parsed {len(records)} Engineering-Scale IFC entities.")
             return ExtractionResult(records=records, diagnostics=diagnostics, success=True)
             
-        except ImportError:
-            logger.error("ifcopenshell not installed. IFC extraction requires this library.")
-            return ExtractionResult(success=False, diagnostics=["Missing ifcopenshell dependency"])
+        except ImportError as e:
+            diagnostic = (
+                "IFC extraction unavailable: optional dependency ifcopenshell is missing. "
+                "No fallback IFC parser is enabled in this build."
+            )
+            logger.error("%s Original import error: %s", diagnostic, e)
+            return ExtractionResult(records=[], success=False, diagnostics=[diagnostic])
         except Exception as e:
             logger.error(f"IFC Extraction failed: {e}")
             return ExtractionResult(success=False, diagnostics=[str(e)])

--- a/src/tests/test_ifc_dependency_contract.py
+++ b/src/tests/test_ifc_dependency_contract.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+import builtins
+import sys
+import types
+from pathlib import Path
+
+from src.engine.extractors.ifc_extractor import IFCExtractor
+
+
+def test_ifc_extractor_supported_extension_remains_ifc():
+    assert IFCExtractor().supported_extensions == [".ifc"]
+
+
+def test_missing_ifcopenshell_fails_honestly_without_records(monkeypatch):
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "ifcopenshell" or name.startswith("ifcopenshell."):
+            raise ImportError("simulated missing ifcopenshell")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    result = IFCExtractor().extract("model.ifc")
+
+    assert result.success is False
+    assert result.records == []
+    diagnostic_text = "\n".join(result.diagnostics).lower()
+    assert "ifcopenshell" in diagnostic_text
+    assert "missing" in diagnostic_text
+    assert "no fallback" in diagnostic_text
+    assert "regex" not in diagnostic_text
+
+
+def test_ifc_extractor_source_does_not_claim_regex_text_fallback():
+    source = Path("src/engine/extractors/ifc_extractor.py").read_text(encoding="utf-8-sig").lower()
+
+    assert "regex/text" not in source
+    assert "good enough for phase 1" not in source
+    assert "no text/regex fallback" in source
+    assert "no fallback ifc parser is enabled" in source
+
+
+class FakeEntity:
+    def __init__(self, entity_type, global_id, name=None):
+        self._entity_type = entity_type
+        self.GlobalId = global_id
+        self.Name = name
+        self.IsDecomposedBy = []
+
+    def is_a(self, entity_type=None):
+        if entity_type is None:
+            return self._entity_type
+        return self._entity_type == entity_type
+
+
+class FakeConnection:
+    def __init__(self):
+        self.RelatingElement = FakeEntity("IfcWall", "wall-guid-001", "Wall")
+        self.RelatedElement = FakeEntity("IfcSlab", "slab-guid-002", "Slab")
+
+    def is_a(self, entity_type=None):
+        if entity_type is None:
+            return "IfcRelConnectsElements"
+        return entity_type == "IfcRelConnectsElements"
+
+
+class FakeModel:
+    def __init__(self):
+        self.project = FakeEntity("IfcProject", "project-guid-001", "Project")
+        self.site = FakeEntity("IfcSite", "site-guid-001", "Site")
+        self.product = FakeEntity("IfcWall", "wall-guid-001", "Wall")
+        self.connection = FakeConnection()
+
+    def by_type(self, entity_type):
+        if entity_type == "IfcProject":
+            return [self.project]
+        if entity_type == "IfcSite":
+            return [self.site]
+        if entity_type == "IfcProduct":
+            return [self.product]
+        if entity_type == "IfcRelConnectsElements":
+            return [self.connection]
+        return []
+
+
+def test_ifc_available_dependency_emits_only_known_contract_record_types(monkeypatch):
+    fake_model = FakeModel()
+
+    ifcopenshell_mod = types.ModuleType("ifcopenshell")
+    util_mod = types.ModuleType("ifcopenshell.util")
+    element_mod = types.ModuleType("ifcopenshell.util.element")
+
+    ifcopenshell_mod.open = lambda file_path: fake_model
+    element_mod.get_psets = lambda product: {
+        "Pset_WallCommon": {"FireRating": "2HR"},
+        "BaseQuantities": {"NetVolume": 12.5},
+    }
+    util_mod.element = element_mod
+    ifcopenshell_mod.util = util_mod
+
+    monkeypatch.setitem(sys.modules, "ifcopenshell", ifcopenshell_mod)
+    monkeypatch.setitem(sys.modules, "ifcopenshell.util", util_mod)
+    monkeypatch.setitem(sys.modules, "ifcopenshell.util.element", element_mod)
+
+    result = IFCExtractor().extract("model.ifc")
+
+    assert result.success is True
+    record_types = {record["type"] for record in result.records}
+    assert record_types == {
+        "ifc_project",
+        "ifc_spatial",
+        "ifc_element_metadata",
+        "ifc_connection",
+    }
+
+    assert all(record["provenance"].get("entity") for record in result.records)
+    assert any("Successfully parsed" in item for item in result.diagnostics)


### PR DESCRIPTION
## Summary

Closes #112.

Completes Upgrade 3E by hardening the IFC dependency and persistence honesty contract without adding dependencies, changing packaging, or rewriting IFC parsing.

## Changes

- `src/engine/extractors/ifc_extractor.py`
  - Removes misleading fallback wording from the extractor docstring.
  - Explicitly states that the current IFC extractor has no text/regex fallback.
  - Makes missing `ifcopenshell` behavior return `success=False`, `records=[]`, and a clear diagnostic:
    - `IFC extraction unavailable: optional dependency ifcopenshell is missing. No fallback IFC parser is enabled in this build.`

- `src/tests/test_ifc_dependency_contract.py`
  - Proves `.ifc` remains the supported extension.
  - Simulates missing `ifcopenshell` without uninstalling packages.
  - Proves missing dependency failure is honest and emits no records.
  - Proves source text no longer claims Regex/Text fallback behavior.
  - Stubs available `ifcopenshell` behavior and proves emitted record types remain within the handled contract:
    - `ifc_project`
    - `ifc_spatial`
    - `ifc_element_metadata`
    - `ifc_connection`

## Non-scope

- No packaging changes.
- No dependency additions.
- No `ifcopenshell` installation or version pinning.
- No IFC parser rewrite.
- No schema migration.
- No OCR/PDF/P6 parser changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM parser.
- No MCP/autonomous loop.
- No audit persistence implementation.
- No snapshot implementation.
- No Document Center redesign.
- No Schedule Truth Workspace implementation.
- No Revit bridge work.

## Verification

Owner-run Windows PowerShell proof:

```text
python -m pytest -q `
  src/tests/test_ifc_dependency_contract.py `
  src/tests/test_ifc_extractor_persistence_contract.py `
  src/tests/test_extractor_registry_reachability.py `
  src/tests/test_file_inspector_evidence_lanes.py
..............                                                                                                   [100%]
14 passed, 5 warnings in 1.00s
```

Scope check:

```text
[PASS] Changed files are within #112 scope.
```

Changed files:

```text
src/engine/extractors/ifc_extractor.py
src/tests/test_ifc_dependency_contract.py
```

Final local status:

```text
git status --short
# clean
```

Branch head:

```text
8fee54f Harden IFC dependency honesty contract
```

## Risk

- Packaging risk: none; no packaging files or dependencies changed.
- Windows risk: low.
- Rollback risk: low/medium because extractor diagnostics and wording changed.
- Architecture risk: reduced by removing fake IFC fallback claims.
- Product risk: reduced by making optional IFC dependency behavior explicit.

## Follow-up

Next likely packet after merge:

```text
Upgrade 3F — Office Typed Persistence Contract Audit/Patch
```