### PR TITLE
Fix P6 critical path unknown honesty

### DIFF
--- a/src/engine/builders/schedule_builder.py
+++ b/src/engine/builders/schedule_builder.py
@@ -1,6 +1,6 @@
 import logging
 import json
-from typing import List, Dict, Any, Optional, Set
+from typing import List, Dict, Any, Optional, Set, Tuple
 from datetime import datetime, timedelta
 
 from src.domain.facts.models import Fact, FactStatus, FactInput, ValueType
@@ -38,7 +38,7 @@ class ScheduleBuilder:
         now = self.db._ts()
         
         # 2. Compute Critical Path
-        critical_path_set = self._compute_critical_path(snapshot_id)
+        critical_path_set, critical_path_known, critical_path_method = self._compute_critical_path(snapshot_id)
         
         # 3. Activity-Level Facts
         status_counts = {}
@@ -101,24 +101,28 @@ class ScheduleBuilder:
             f_dates.inputs.append(FactInput(file_version_id=snapshot_id, location={"table": "TASK", "row_id": act_id}))
             facts.append(f_dates)
             
-            # 3. NEW: Critical Path Membership
-            is_critical = code in critical_path_set
-            f_critical = Fact(
-                fact_id=f"fact_sched_critical_{act_id}",
-                project_id=project_id,
-                fact_type="schedule.critical_path_membership",
-                subject_kind="activity",
-                subject_id=code,
-                as_of={"file_version_id": snapshot_id},
-                value_type=ValueType.BOOL,
-                value=is_critical,
-                status=FactStatus.CANDIDATE,
-                method_id="schedule_builder_v1_cpm",
-                created_at=now,
-                updated_at=now
-            )
-            f_critical.inputs.append(FactInput(file_version_id=snapshot_id, location={"table": "TASK", "row_id": act_id}))
-            facts.append(f_critical)
+            # 3. Critical Path Membership
+            # Only emit critical-path membership facts when the source schedule
+            # contains usable total-float data. Without usable float and without
+            # a CPM engine, critical path is unknown, not false.
+            if critical_path_known:
+                is_critical = code in critical_path_set
+                f_critical = Fact(
+                    fact_id=f"fact_sched_critical_{act_id}",
+                    project_id=project_id,
+                    fact_type="schedule.critical_path_membership",
+                    subject_kind="activity",
+                    subject_id=code,
+                    as_of={"file_version_id": snapshot_id},
+                    value_type=ValueType.BOOL,
+                    value=is_critical,
+                    status=FactStatus.CANDIDATE,
+                    method_id=f"schedule_builder_v1_{critical_path_method}",
+                    created_at=now,
+                    updated_at=now
+                )
+                f_critical.inputs.append(FactInput(file_version_id=snapshot_id, location={"table": "TASK", "row_id": act_id}))
+                facts.append(f_critical)
             
             #4. NEW: Total Float as separate fact
             if r_dict.get("total_float") is not None:
@@ -200,23 +204,32 @@ class ScheduleBuilder:
             facts.append(f_status_count)
         
         # 5b. Critical path activity count
-        f_cp_count = Fact(
-            fact_id=f"fact_sched_critical_count_{snapshot_id[:8]}",
-            project_id=project_id,
-            fact_type="schedule.critical_path_activity_count",
-            subject_kind="project",
-            subject_id=project_id,
-            as_of={"file_version_id": snapshot_id},
-            value_type=ValueType.NUM,
-            value=len(critical_path_set),
-            unit="activities",
-            status=FactStatus.CANDIDATE,
-            method_id="schedule_builder_v1_cpm",
-            created_at=now,
-            updated_at=now
-        )
-        f_cp_count.inputs.append(FactInput(file_version_id=snapshot_id, location={"table": "p6_activities"}))
-        facts.append(f_cp_count)
+        # Emit a zero count only when critical-path availability is known from
+        # usable total-float data. If no usable float exists, do not convert
+        # unknown critical path into a false zero-count fact.
+        if critical_path_known:
+            f_cp_count = Fact(
+                fact_id=f"fact_sched_critical_count_{snapshot_id[:8]}",
+                project_id=project_id,
+                fact_type="schedule.critical_path_activity_count",
+                subject_kind="project",
+                subject_id=project_id,
+                as_of={"file_version_id": snapshot_id},
+                value_type=ValueType.NUM,
+                value=len(critical_path_set),
+                unit="activities",
+                status=FactStatus.CANDIDATE,
+                method_id=f"schedule_builder_v1_{critical_path_method}",
+                created_at=now,
+                updated_at=now
+            )
+            f_cp_count.inputs.append(FactInput(file_version_id=snapshot_id, location={"table": "p6_activities"}))
+            facts.append(f_cp_count)
+        else:
+            logger.warning(
+                "[ScheduleBuilder] Critical path facts skipped for snapshot %s because usable total_float data is unavailable.",
+                snapshot_id,
+            )
         
         # 5c. Milestone forecast dates
         for milestone in milestone_activities:
@@ -240,51 +253,53 @@ class ScheduleBuilder:
         logger.info(f"[ScheduleBuilder] Generated {len(facts)} facts ({len(critical_path_set)} critical activities)")
         return facts
     
-    def _compute_critical_path(self, snapshot_id: str) -> Set[str]:
+    def _compute_critical_path(self, snapshot_id: str) -> Tuple[Set[str], bool, str]:
         """
-        Compute critical path using CPM algorithm (forward/backward pass).
-        Returns set of activity codes on the critical path.
+        Determine critical-path membership from P6-provided total float only.
+
+        Returns:
+            (critical_activity_codes, critical_path_known, method)
+
+        This method intentionally does not run a fallback CPM engine. If no
+        usable total-float values exist, critical path is unknown and downstream
+        fact emission must not turn that into non-critical False / zero-count
+        facts.
         """
-        # Load activities and relations
         activities_rows = self.db.execute(
-            "SELECT activity_id, code, start_date, finish_date, total_float FROM p6_activities WHERE file_version_id = ?",
-            (snapshot_id,)
-        ).fetchall()
-        
-        relations_rows = self.db.execute(
-            """
-            SELECT 
-                p.code as pred_code, 
-                s.code as succ_code,
-                r.rel_type,
-                r.lag
-            FROM p6_relations r
-            JOIN p6_activities p ON r.pred_activity_id = p.activity_id
-            JOIN p6_activities s ON r.succ_activity_id = s.activity_id
-            WHERE r.file_version_id = ?
-            """,
+            "SELECT activity_id, code, total_float FROM p6_activities WHERE file_version_id = ?",
             (snapshot_id,)
         ).fetchall()
         
         if not activities_rows:
-            return set()
+            return set(), False, "no_activities"
         
-        # Strategy 1: Use P6-provided total_float (most reliable if P6 computed correctly)
-        # Activities with total_float <= 0 are on critical path
-        critical_set = set()
+        critical_set: Set[str] = set()
+        has_usable_float = False
+
         for row in activities_rows:
             r_dict = dict(row)
             total_float = r_dict.get("total_float")
-            if total_float is not None and total_float <= 0:
+            if total_float in (None, ""):
+                continue
+
+            try:
+                total_float_value = float(total_float)
+            except (TypeError, ValueError):
+                continue
+
+            has_usable_float = True
+            if total_float_value <= 0:
                 critical_set.add(r_dict["code"])
         
-        # If P6 float is available and we found critical activities, trust it
-        if critical_set:
-            logger.info(f"[CPM] Using P6-provided float: {len(critical_set)} critical activities")
-            return critical_set
+        if has_usable_float:
+            logger.info(
+                "[CPM] Using P6-provided total_float: %s critical activities",
+                len(critical_set),
+            )
+            return critical_set, True, "p6_total_float"
         
-        # Strategy 2: Fallback CPM calculation (if P6 float missing)
-        # This is complex and requires proper forward/backward pass
-        # For now, return empty set if P6 float not available
-        logger.warning("[CPM] No total_float data from P6, critical path unknown")
-        return set()
+        logger.warning(
+            "[CPM] No usable total_float data from P6; critical path is unknown. "
+            "No CPM fallback is enabled in this build."
+        )
+        return set(), False, "unknown_no_usable_total_float"

--- a/src/tests/test_p6_critical_path_unknown_honesty.py
+++ b/src/tests/test_p6_critical_path_unknown_honesty.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+
+from src.application.jobs.extract_job import ExtractJob
+from src.engine.builders.schedule_builder import ScheduleBuilder
+from src.engine.extractors.p6_extractor import P6Extractor
+from src.infra.persistence.database_manager import DatabaseManager
+
+
+XER_BASE = """%T\tPROJECT
+%F\tproj_id\tproj_short_name
+%R\tP1\tDemo
+%T\tPROJWBS
+%F\twbs_id\tproj_id\tparent_wbs_id\twbs_short_name\twbs_name
+%R\tW1\tP1\t\tWBS\tMain WBS
+%T\tTASK
+%F\ttask_id\tproj_id\twbs_id\ttask_code\ttask_name\ttarget_start_date\ttarget_end_date\tstatus_code\ttotal_float_hr_cnt
+{task_rows}
+%T\tTASKPRED
+%F\tproj_id\ttask_id\tpred_task_id\tpred_type\tlag
+%R\tP1\tA2\tA1\tFS\t0
+"""
+
+
+def _run_xer_to_facts(tmp_path, task_rows: str):
+    db = DatabaseManager(root_dir=str(tmp_path), project_id="ProjectA")
+    xer = XER_BASE.format(task_rows=task_rows)
+    path = tmp_path / "schedule.xer"
+    path.write_text(xer, encoding="latin-1")
+
+    now = db._ts()
+    db.execute(
+        "INSERT INTO file_registry (file_id, project_id, first_seen_path, created_at) VALUES (?, ?, ?, ?)",
+        ("file_p6", "ProjectA", str(path), now),
+    )
+    db.execute(
+        "INSERT INTO file_versions (file_version_id, file_id, sha256, size_bytes, file_ext, imported_at, source_path) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("fv_p6", "file_p6", "hash-p6", path.stat().st_size, ".xer", now, str(path)),
+    )
+    db.commit()
+
+    job = ExtractJob("job_p6", "ProjectA", "fv_p6", extractor_name="p6")
+    result = P6Extractor().extract(str(path))
+    assert result.success is True
+
+    for record in result.records:
+        job._insert_record(db, record, doc_id="doc_p6")
+
+    facts = ScheduleBuilder(db).build("ProjectA", "fv_p6")
+    return db, result, facts
+
+
+def _facts_by_type(facts, fact_type):
+    return [fact for fact in facts if fact.fact_type == fact_type]
+
+
+def _critical_memberships(facts):
+    return _facts_by_type(facts, "schedule.critical_path_membership")
+
+
+def _critical_counts(facts):
+    return _facts_by_type(facts, "schedule.critical_path_activity_count")
+
+
+def test_valid_negative_and_positive_float_still_emits_known_critical_facts(tmp_path):
+    _, _, facts = _run_xer_to_facts(
+        tmp_path,
+        "\n".join(
+            [
+                "%R\tA1\tP1\tW1\tA-001\tCritical Activity\t2026-01-01\t2026-01-05\tTK_Complete\t-8",
+                "%R\tA2\tP1\tW1\tA-002\tNon Critical Activity\t2026-01-06\t2026-01-10\tTK_Active\t16",
+            ]
+        ),
+    )
+
+    memberships = {fact.subject_id: fact.value for fact in _critical_memberships(facts)}
+    assert memberships == {"A-001": True, "A-002": False}
+
+    counts = _critical_counts(facts)
+    assert len(counts) == 1
+    assert counts[0].value == 1
+    assert counts[0].method_id == "schedule_builder_v1_p6_total_float"
+    assert all(fact.status.value == "CANDIDATE" for fact in memberships and _critical_memberships(facts))
+
+
+def test_all_positive_usable_float_is_known_zero_critical_path(tmp_path):
+    _, _, facts = _run_xer_to_facts(
+        tmp_path,
+        "\n".join(
+            [
+                "%R\tA1\tP1\tW1\tA-001\tPositive Float Activity 1\t2026-01-01\t2026-01-05\tTK_Complete\t8",
+                "%R\tA2\tP1\tW1\tA-002\tPositive Float Activity 2\t2026-01-06\t2026-01-10\tTK_Active\t16",
+            ]
+        ),
+    )
+
+    memberships = {fact.subject_id: fact.value for fact in _critical_memberships(facts)}
+    assert memberships == {"A-001": False, "A-002": False}
+
+    counts = _critical_counts(facts)
+    assert len(counts) == 1
+    assert counts[0].value == 0
+    assert counts[0].method_id == "schedule_builder_v1_p6_total_float"
+
+
+def test_missing_and_malformed_float_do_not_emit_false_or_zero_critical_path_facts(tmp_path):
+    _, extraction, facts = _run_xer_to_facts(
+        tmp_path,
+        "\n".join(
+            [
+                "%R\tA1\tP1\tW1\tA-001\tMissing Float Activity\t2026-01-01\t2026-01-05\tTK_Complete",
+                "%R\tA2\tP1\tW1\tA-002\tMalformed Float Activity\t2026-01-06\t2026-01-10\tTK_Active\tnot-a-number",
+            ]
+        ),
+    )
+
+    extracted_activities = [record for record in extraction.records if record["type"] == "p6_activity"]
+    assert [activity["data"]["total_float"] for activity in extracted_activities] == [None, None]
+
+    assert _critical_memberships(facts) == []
+    assert _critical_counts(facts) == []
+
+    assert _facts_by_type(facts, "schedule.activity")
+    assert _facts_by_type(facts, "schedule.dates")
+    assert _facts_by_type(facts, "schedule.logic")
+    assert _facts_by_type(facts, "schedule.activity_count_by_status")
+
+
+def test_schedule_builder_helper_reports_unknown_when_no_usable_float(tmp_path):
+    db, _, _ = _run_xer_to_facts(
+        tmp_path,
+        "\n".join(
+            [
+                "%R\tA1\tP1\tW1\tA-001\tMissing Float Activity\t2026-01-01\t2026-01-05\tTK_Complete",
+                "%R\tA2\tP1\tW1\tA-002\tBlank Float Activity\t2026-01-06\t2026-01-10\tTK_Active",
+            ]
+        ),
+    )
+
+    critical_set, known, method = ScheduleBuilder(db)._compute_critical_path("fv_p6")
+
+    assert critical_set == set()
+    assert known is False
+    assert method == "unknown_no_usable_total_float"
+
+
+def test_p6_visualizer_label_marks_gantt_as_raw_float_derived_not_certified_truth():
+    source = Path("src/ui/panels/p6_visualizer.py").read_text(encoding="utf-8-sig")
+
+    assert "Raw P6 staging Gantt" in source
+    assert "float-derived, not certified critical-path truth" in source
+    assert "Interactive Gantt | Click any bar to inspect Layer 4 Certified Facts" not in source

--- a/src/ui/panels/p6_visualizer.py
+++ b/src/ui/panels/p6_visualizer.py
@@ -27,7 +27,7 @@ class P6Visualizer(ctk.CTkFrame):
         self.frame_ctrl = ctk.CTkFrame(self, fg_color=Theme.BG_DARKER, corner_radius=12, border_width=1, border_color=Theme.BG_DARK)
         self.frame_ctrl.pack(fill="x", padx=20, pady=10)
         
-        self.lbl_info = ctk.CTkLabel(self.frame_ctrl, text="Interactive Gantt | Click any bar to inspect Layer 4 Certified Facts", 
+        self.lbl_info = ctk.CTkLabel(self.frame_ctrl, text="Raw P6 staging Gantt | Bar color is float-derived, not certified critical-path truth | Click any bar to inspect certified facts", 
                                     font=Theme.FONT_BODY, text_color=Theme.TEXT_MUTED)
         self.lbl_info.pack(side="left", padx=20, pady=10)
         


### PR DESCRIPTION
## Summary

Closes #118.

Fixes the narrow P6/Schedule honesty defect found by #117: missing or unusable total float no longer becomes false non-critical membership facts or a zero critical-path count fact.

## Changes

- `src/engine/builders/schedule_builder.py`
  - Changes `_compute_critical_path(...)` to return:
    - critical activity code set;
    - whether critical path is known;
    - method label.
  - Uses P6-provided total float only.
  - Does not implement fallback CPM.
  - Emits `schedule.critical_path_membership` facts only when at least one usable total-float value exists.
  - Emits `schedule.critical_path_activity_count` only when total-float availability is known.
  - Preserves other supported schedule facts when critical path is unknown.

- `src/ui/panels/p6_visualizer.py`
  - Updates Gantt label to state that the chart is raw P6 staging and bar color is float-derived, not certified critical-path truth.
  - Keeps the click audit path to inspect certified facts.

- `src/tests/test_p6_critical_path_unknown_honesty.py`
  - Proves valid negative/positive float still emits known critical-path candidate facts.
  - Proves all-positive usable float can honestly emit known false memberships and zero critical count.
  - Proves missing/malformed float emits no critical-path membership/count facts.
  - Proves other schedule facts continue to build when critical path is unknown.
  - Proves the Gantt label no longer implies certified critical-path truth.

## Locked policy

```text
Usable P6 total float exists:
  emit candidate critical membership/count facts.

All usable floats are positive:
  emit known False memberships and zero critical count.

No usable total float exists:
  emit no critical_path_membership facts.
  emit no critical_path_activity_count fact.
  preserve other supported schedule facts.
```

## Non-scope

- No packaging changes.
- No dependency additions.
- No broad P6 parser rewrite.
- No CPM engine implementation.
- No Schedule Truth Workspace implementation.
- No Gantt redesign.
- No chat schedule-tool implementation.
- No OCR/PDF/IFC/Office parser changes.
- No runtime/provider/provisioning changes.
- No quantization/model-catalog changes.
- No chat tool execution bridge.
- No LLM parser.
- No MCP/autonomous loop.
- No audit persistence implementation.
- No snapshot implementation.
- No Revit bridge work.
- No Total Quality Upgrade branch changes.

## Verification

Owner-run Windows PowerShell proof:

```text
python -m pytest -q `
  src/tests/test_p6_critical_path_unknown_honesty.py `
  src/tests/test_p6_truth.py `
  src/tests/test_truth_state_enforcement.py `
  src/tests/test_file_inspector_evidence_lanes.py
.....................                                                                                            [100%]
21 passed, 5 warnings in 3.52s
```

Changed files:

```text
src/engine/builders/schedule_builder.py
src/ui/panels/p6_visualizer.py
src/tests/test_p6_critical_path_unknown_honesty.py
```

Final local status:

```text
git status --short
# clean
```

Branch head:

```text
0564b93 Fix P6 critical path unknown honesty
```

## Risk

- Packaging risk: none.
- Windows risk: low.
- Rollback risk: low/medium because schedule critical-path fact emission changes for unknown-float schedules.
- Architecture risk: reduced by preventing unknown critical path from becoming false/zero truth.
- Product risk: reduced by avoiding critical-path overclaiming.

## Follow-up

After merge and hygiene, choose one:

```text
Upgrade 3J — Schedule Truth Workspace Design Issue
```

or

```text
Upgrade 3J — P6 Relation Uniqueness/Fidelity Patch
```