### PR TITLE
Refresh publication documentation and repository hygiene

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+about: Report a reproducible SerapeumAI issue
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Environment
+
+- Windows version:
+- Source run or packaged run:
+- Commit or artifact identity:
+- Local runtime state:
+
+## Summary
+
+Describe the issue.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What should happen?
+
+## Actual behavior
+
+What happened instead?
+
+## Evidence
+
+Paste terminal output, log tail, screenshots, or exact error messages.
+
+## Scope
+
+Check any that apply:
+
+- [ ] Dashboard
+- [ ] Documents / File Inspector
+- [ ] Facts / lineage
+- [ ] Expert Chat
+- [ ] Runtime/model
+- [ ] Packaging
+- [ ] Shutdown
+
+## Notes
+
+Add any relevant caveats or context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+## Task class
+
+Choose one:
+
+- source task
+- test task
+- packaging task
+- release task
+- documentation task
+
+## Summary
+
+Describe the change in a few lines.
+
+## Touched files
+
+List the files changed.
+
+## Scope control
+
+Confirm:
+
+- [ ] No unrelated changes.
+- [ ] No dependency additions/upgrades unless explicitly approved.
+- [ ] No packaging-file changes unless explicitly approved.
+- [ ] No build/dist/cache artifacts committed.
+
+## Packaging / Windows risk
+
+- Packaging risk:
+- Windows risk:
+- Rollback risk:
+
+## Verification
+
+Paste exact commands and results.
+
+## Notes
+
+Include caveats, follow-up issues, or intentionally deferred items.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## Unreleased / release candidate
+
+Authority:
+
+```text
+commit: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+artifact: dist\SerapeumAI_Portable\SerapeumAI.exe
+artifact size: 110206723 bytes
+```
+
+### Added
+
+- Repository publication documentation and hygiene surface.
+- Root Apache-2.0 license file.
+- Project notice and third-party notices summary.
+- Install, troubleshooting, privacy, support, contribution, and security docs.
+- Release notes capturing current packaging-pass artifact and caveats.
+
+### Current release-candidate proof
+
+- Source regression passed.
+- Manual source smoke passed with caveats.
+- Documentation honesty passed.
+- Packaging proof passed.
+- Packaged app smoke passed.
+
+### Caveats
+
+- Broader-machine validation remains useful before a wider public announcement.
+- Constrained 8 GB VRAM machines may show runtime/VRAM/thermal caveats.
+- Page-level model-output parse retries can occur during AI-assisted analysis.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Code of Conduct
+
+SerapeumAI project discussions should remain professional, evidence-focused, and respectful.
+
+## Expected behavior
+
+- Keep discussion technical and constructive.
+- Provide reproducible evidence when reporting defects.
+- Respect confidentiality of project files, client data, and private runtime details.
+- Avoid personal attacks, harassment, or inflammatory language.
+
+## Unacceptable behavior
+
+- Sharing confidential project documents or credentials publicly.
+- Posting abusive or discriminatory content.
+- Derailing technical threads with unrelated conflict.
+- Pressuring maintainers to bypass release, safety, or packaging gates.
+
+## Enforcement
+
+The repository owner may edit, hide, lock, or close issues and pull requests that violate these expectations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+SerapeumAI is a Windows-first, local-first AECO review workspace. Contributions must preserve the product's truth, evidence, and packaging discipline.
+
+## Repository rules
+
+- Treat `src/**` as the primary editable code surface.
+- Edit `run.py` and `run_tests.py` only when needed.
+- Treat these packaging files as sensitive:
+  - `SerapeumAI_Portable.spec`
+  - `build_portable.ps1`
+  - `build_portable.bat`
+- Do not treat these as normal editing targets:
+  - `build/**`
+  - `dist/**`
+  - `.serapeum/**`
+  - `models/**`
+  - `**/__pycache__/**`
+- Avoid dependency additions or upgrades unless explicitly approved.
+- Preserve Windows portability and packaged-app behavior.
+- Prefer minimal, reviewable diffs.
+
+## Product rules
+
+- Deterministic extraction and AI-generated support must remain separated.
+- Trusted facts are stronger than retrieval/vector support.
+- Vector stores are derived support, not truth authority.
+- AI Output Only is non-governing unless promoted through review/certification.
+- Do not introduce claims of guaranteed legal, contractual, regulatory, or compliance approval.
+
+## Pull request expectations
+
+Each PR should include:
+
+- task class;
+- files touched;
+- risk frame;
+- verification steps;
+- whether packaging or Windows behavior is affected;
+- rollback notes.
+
+## Verification
+
+Use focused tests for bounded changes. For release-sensitive changes, include Windows-specific proof when relevant.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,41 @@
+# Install and Run
+
+SerapeumAI is currently a Windows-first local desktop application.
+
+## Development run
+
+From the repository root:
+
+```powershell
+python run.py
+```
+
+## Packaged executable
+
+After a successful packaging proof, the portable executable is expected at:
+
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+```
+
+The current release-candidate artifact recorded in #125 is:
+
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+size: 110206723 bytes
+commit: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+```
+
+## Runtime expectations
+
+The current mounted runtime path expects a local LM Studio-compatible runtime to be available for model-backed analysis/chat features.
+
+The application should still surface runtime state honestly when the runtime or model is not ready.
+
+## System tools
+
+Some document-processing paths may rely on local system tools such as Tesseract OCR or Poppler/PDF utilities when installed. Missing tools should be treated as local capability limitations rather than silent success.
+
+## What this app is not
+
+SerapeumAI does not provide guaranteed legal, contractual, regulatory, or compliance approval. It provides review assistance with evidence and provenance.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,10 @@
+SerapeumAI
+Copyright 2025 Ahmed Gaballa
+
+This product includes software and documentation developed for the SerapeumAI project.
+
+SerapeumAI is distributed under the Apache License, Version 2.0. See LICENSE.
+
+SerapeumAI is a local-first AECO review workspace. It provides evidence-backed review assistance and does not provide legal, contractual, regulatory, or guaranteed-compliance approval.
+
+Third-party dependency and runtime notes are summarized in THIRD_PARTY_NOTICES.md.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,22 @@
+# Privacy
+
+SerapeumAI is designed as a local-first desktop review workspace.
+
+## Default posture
+
+- Project documents are processed in the local project workspace.
+- Project storage is local to the application/project `.serapeum` locations.
+- The current release-candidate workflow uses a local runtime path for model-backed features.
+- SerapeumAI does not require a cloud service for the proven packaged workflow.
+
+## Local runtime note
+
+If a user configures external providers or non-default endpoints in the future, that provider may have its own data-handling behavior. The current release-candidate public docs do not claim external-provider privacy guarantees.
+
+## Project data
+
+Users are responsible for deciding what project documents they import and for protecting confidential project files according to their own project, employer, and client requirements.
+
+## Product boundary
+
+SerapeumAI provides review assistance with evidence and provenance. It does not provide guaranteed legal, contractual, regulatory, or compliance approval.

--- a/README.md
+++ b/README.md
@@ -1,150 +1,188 @@
 # SerapeumAI
 
-SerapeumAI is a Windows-first, local-first AECO review workspace.
+SerapeumAI is a **Windows-first, local-first AECO review workspace** for evidence-backed project review.
 
 It helps engineers and reviewers:
 
-- ingest project files into a project workspace
-- inspect deterministic extraction and AI analysis separately
-- review facts on the Facts page with lineage / evidence support
-- ask questions in Expert Chat and get a direct answer first, with optional evidence behind it
+- ingest project files into a local project workspace;
+- inspect deterministic extraction and AI-generated support separately;
+- review facts on the Facts page with lineage and evidence;
+- ask project questions in Expert Chat with direct answers and optional evidence lanes.
 
-SerapeumAI is **review assistance** with evidence and provenance. It is **not** a guaranteed-compliance, legal approval, or autonomous design-authoring engine.
+SerapeumAI is **review assistance** with evidence and provenance. It is **not** a guaranteed-compliance engine, legal approval engine, autonomous design-authoring tool, or generic chatbot.
 
-## Run
+---
 
-Use one clear dev run path:
+## Current publication status
+
+Current release candidate authority:
+
+```text
+main includes PR #123
+commit: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+latest completed gate: #125 — Final Packaging Proof Gate
+artifact: dist\SerapeumAI_Portable\SerapeumAI.exe
+artifact size: 110206723 bytes
+```
+
+Release evidence currently recorded:
+
+- final Windows source regression: **PASS**;
+- manual source smoke: **PASS with caveats**;
+- documentation honesty checkpoint: **PASS**;
+- final packaging proof: **PASS**;
+- packaged app smoke: **PASS**;
+- final owner publish decision: **pending** in issue #126.
+
+A GitHub Release/tag has not been created by this README.
+
+---
+
+## Supported posture
+
+- Baseline platform: **Windows**.
+- Core posture: **local-first** and **project-local**.
+- Runtime expectation: local LM Studio-compatible runtime for the current mounted runtime path.
+- Current publish generative runtime: `qwen2.5-coder-7b-instruct`.
+- Embeddings remain separate from the generative model.
+- Calculations and deterministic checks must be performed by application code/tools, not by LLM arithmetic.
+
+---
+
+## Quick start
+
+Development run path:
 
 ```powershell
 python run.py
 ```
 
-## Runtime contract
+Packaged release-candidate path after a successful local build:
 
-- Windows is the baseline platform.
-- LM Studio must be installed and running locally for the current mounted runtime path.
-- The publish generative runtime is the single model `qwen2.5-coder-7b-instruct`.
-- Embeddings remain separate from the generative model.
-- Calculations and deterministic checks must be performed by application code/tools, not by LLM arithmetic.
+```powershell
+.\dist\SerapeumAI_Portable\SerapeumAI.exe
+```
+
+For setup and runtime notes, see:
+
+- `INSTALL.md`
+- `TROUBLESHOOTING.md`
+- `RELEASE_NOTES.md`
+
+---
 
 ## Mounted workflow
 
+- **Dashboard**: project counts, runtime state, pipeline diagnostics, and honesty-oriented health labels.
 - **Documents**: browse project documents and open the File Inspector.
-- **Schedule page**: inspect the project schedule and click activities to open linked schedule fact/evidence detail where available.
 - **File Inspector**:
   1. Consolidated Review
   2. Full Metadata
   3. Raw Deterministic Extraction
   4. AI Output Only
-- **Facts page**: review facts, inspect meaning, inspect provenance, and certify or reject with evidence.
+- **Facts**: review facts, inspect meaning/source/review state, and open lineage/evidence.
 - **Expert Chat**:
-  - shows a direct answer first
-  - can show a compact source-basis banner when helpful
-  - keeps behind-the-scenes evidence behind an optional **Show Evidence** action
-  - exposes these evidence lanes only when expanded:
-    - Trusted Facts
-    - Extracted Evidence
-    - Linked Support
-    - AI-Generated Synthesis
-  - resets visible chat history when the active project closes or changes
-  - drops late responses/errors from old project sessions
+  - shows a direct answer first;
+  - labels the basis of the answer;
+  - exposes optional evidence lanes;
+  - resets visible chat history when the active project closes or changes;
+  - drops late responses/errors from old project sessions.
 
-## Trust and provenance
+---
 
-- Trusted Facts remain the strongest source class.
+## Trust and provenance model
+
 - `VALIDATED` and `HUMAN_CERTIFIED` facts are trusted answer sources.
-- `CANDIDATE` facts are visible for review but do not govern answers.
+- `CANDIDATE` facts are visible for review but do not silently govern answers.
 - `REJECTED` facts are excluded from trusted answer paths.
-- AI-generated synthesis is clearly labeled non-governing.
-- Linked Support is clearly labeled support, not certified truth.
-- When trusted facts are incomplete, SerapeumAI may answer from grounded extraction or linked support only when that source class is explicitly labeled.
-
-## Evidence and inspection
-
-- Deterministic extraction and parser/OCR output must remain separated from AI/VLM output.
-- File Inspector separates:
-  - consolidated review,
-  - full metadata,
-  - raw deterministic extraction,
-  - AI output only.
-- AI/VLM output does not become certified truth unless promoted through the review/certification workflow.
-- Deterministic extraction evidence can build trusted document facts through the build-facts path.
-
-## Storage and project isolation
-
-- Persistent project storage is localized under the project `.serapeum` root.
-- The normal SQLite database is the authority.
+- Deterministic extraction and parser/OCR output remain separate from AI-generated support.
+- AI Output Only is non-governing unless promoted through review/certification.
 - Vector/retrieval stores are derived support, not governing truth.
 - Project A must not answer from Project B.
-- Mounted chat requests are bound to the active project/session.
 
-## Dashboard honesty
+---
 
-- Dashboard labels must not overclaim health or trust.
-- Qualified facts are counted separately from all built facts.
-- Missing optional extractor/runtime columns must degrade safely.
-- Schedule/P6 truth labels must not claim verified critical path unless deterministic float data supports it.
+## Current proven behavior
 
-## Clean shutdown
+Completed proof rails include:
 
-- Red-X close should internally close the project before destroying the app window.
-- Closing the main window should end the live session cleanly.
-- Background analysis should stop cleanly when the app is closed.
-- Reopening the app should not silently resume abandoned prior work without a new explicit user trigger.
+- mounted chat active-project authority and project isolation;
+- sourced answer authority labeling;
+- support-only answer labeling;
+- snapshot/imported-date wording honesty;
+- PDF metadata completeness and routing proof;
+- IFC dependency/no-fallback honesty;
+- Office/DGN flattened extraction contract;
+- P6 critical-path unknown honesty;
+- P6 relation uniqueness/fidelity;
+- File Inspector four-lane separation;
+- final packaging proof and packaged-app smoke.
 
-## Schedule interaction
+---
 
-- The Schedule page should allow clicking a schedule/Gantt activity without crashing.
-- If linked schedule facts are available, they should be shown.
-- If evidence is unavailable, the app should degrade gracefully and say so honestly.
+## Explicit non-enabled behavior
 
-## Interactive responsiveness
+The current repository does **not** enable or claim:
 
-- Interactive chat should stay responsive even when background ingest/extract work exists.
-- Background backlog should yield to active chat use in the mounted workflow.
+- autonomous chat tool execution;
+- LLM tool-call parser in the visible chat UI;
+- MCP integration;
+- autonomous agent loops;
+- audit persistence implementation;
+- project memory implementation;
+- runtime/provider provisioning or model download control;
+- snapshot governance implementation;
+- Revit bridge;
+- Schedule Truth Workspace implementation;
+- CPM engine;
+- PDF VLM routing;
+- IFC fallback parser when `ifcopenshell` is missing;
+- typed Office/CAD persistence;
+- generic Excel workbook semantic persistence;
+- guaranteed legal, contractual, regulatory, or compliance approval.
 
-## Current release honesty checkpoint
+---
 
-Current authority after the latest evidence rail:
+## Known caveats
+
+The current artifact passed packaging and packaged smoke, but these caveats remain important for release notes and troubleshooting:
+
+- constrained 8 GB VRAM laptops may show runtime, VRAM, or GPU-temperature warnings;
+- model routing may downgrade analysis to chat when VRAM is limited;
+- embeddings may load on CPU when VRAM is reserved or insufficient;
+- page-level LLM JSON parse retries/errors can occur during analysis;
+- these caveats do not change deterministic extraction, facts, evidence lanes, or packaged smoke proof.
+
+---
+
+## Repository and contribution rules
+
+- `src/**` is the primary editable source surface.
+- `run.py` and `run_tests.py` are editable only when needed.
+- `SerapeumAI_Portable.spec`, `build_portable.ps1`, and `build_portable.bat` are sensitive packaging files.
+- Do not treat `build/**`, `dist/**`, `.serapeum/**`, `models/**`, or `**/__pycache__/**` as normal editing targets.
+- Avoid dependency upgrades unless explicitly approved.
+- Preserve Windows portability and packaging behavior.
+- Prefer minimal, reviewable diffs.
+
+See `CONTRIBUTING.md` for details.
+
+---
+
+## License
+
+SerapeumAI is released under the Apache License, Version 2.0. See `LICENSE` and `NOTICE`.
+
+Third-party dependency and runtime notes are summarized in `THIRD_PARTY_NOTICES.md`.
+
+---
+
+## Future planning
+
+The branch below is preserved as a parked future-upgrade planning branch only:
 
 ```text
-main includes PR #121
-latest main SHA: e5bdf53913cd25ac464ce36feb98ff3ab66b0065
-latest completed packet: #120 / PR #121 — P6 relation uniqueness/fidelity proof
+docs/total-quality-upgrade-v3-3
 ```
 
-Completed and test-locked behavior includes:
-
-- Workspace Honesty:
-  - mounted chat is bound to the active project/session;
-  - support-only answers are labeled as support, not certified truth;
-  - snapshot/imported-date wording is informational only;
-  - cross-project answer leakage has regression coverage.
-- Engineering Evidence:
-  - PDF metadata completeness and routing are test-locked;
-  - IFC missing dependency behavior is honest and has no fallback parser claim;
-  - Word/PPTX/DGN extraction is flattened deterministic extraction, not typed Office/CAD persistence;
-  - Excel extraction is register/log-row oriented, not generic workbook semantic persistence;
-  - P6 critical-path unknown handling does not convert unknown into false/zero facts;
-  - P6 relation fidelity preserves distinct relation rows with different type or lag.
-
-Current explicit limitations:
-
-- No final publish pass has been issued.
-- No packaging rebuild is authorized by this README.
-- No CPM engine is implemented.
-- No Schedule Truth Workspace implementation is complete.
-- No PDF VLM routing is enabled.
-- No typed Office/CAD persistence is implemented.
-- No generic Excel workbook semantic persistence is implemented.
-- No IFC fallback parser is enabled when `ifcopenshell` is missing.
-- No autonomous chat tool execution, MCP integration, or runtime provisioning/download/control is enabled.
-- `docs/total-quality-upgrade-v3-3` remains preserved as future planning only, not current release authority.
-
-Before a publish pass, run the final local Windows release test and packaging proof.
-
-See:
-
-```text
-docs/internal/PUBLISH_TRUTH_STATEMENT.md
-```
+It is not the current release authority and must be reconciled against `main` before future implementation.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,80 @@
+# SerapeumAI Release Notes
+
+## Release candidate after final packaging proof
+
+Status: release candidate available; owner publish decision pending in #126.
+
+### Authority
+
+```text
+main includes PR #123
+commit: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+final packaging issue: #125 — PACKAGING PASS
+publication hygiene issue: #127 — active before final publish decision
+```
+
+### Artifact
+
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+size: 110206723 bytes
+```
+
+No GitHub Release/tag is created by this file.
+
+---
+
+## Passed gates
+
+- Release-relevant source regression: 115 passed in 1.81s.
+- Manual source workflow smoke: passed with caveats.
+- Documentation honesty checkpoint: passed.
+- Existing packaging script: passed with exit code 0.
+- Packaged executable: produced, fresh, and non-empty.
+- Packaged app smoke: passed on Windows.
+- Packaged File Inspector lanes: passed.
+- Packaged Facts page and lineage/evidence popup: passed.
+- Packaged Expert Chat evidence-labeled answer: passed.
+- Shutdown tail: no Tk post-destroy / bgerror / invalid command noise observed.
+
+---
+
+## Known caveats
+
+- Constrained 8 GB VRAM laptops may show runtime, VRAM, or GPU-temperature warnings.
+- Model routing may downgrade analysis to chat when VRAM is limited.
+- Embeddings may load on CPU when VRAM is reserved or insufficient.
+- Page-level LLM JSON parse retries/errors can occur during analysis.
+- These are runtime/performance/analysis-quality caveats, not current packaging blockers.
+
+---
+
+## Explicit non-enabled behavior
+
+The current release candidate does not enable or claim:
+
+- autonomous chat tool execution;
+- MCP integration;
+- autonomous agent loops;
+- runtime provider provisioning or model download control;
+- Revit bridge;
+- Schedule Truth Workspace implementation;
+- CPM engine;
+- PDF VLM routing;
+- IFC fallback parser when `ifcopenshell` is missing;
+- typed Office/CAD persistence;
+- generic Excel workbook semantic persistence;
+- guaranteed legal, contractual, regulatory, or compliance approval.
+
+---
+
+## Release decision status
+
+The final publish decision is intentionally separate from packaging proof.
+
+Allowed decisions in #126:
+
+- publish now / create GitHub Release;
+- hold artifact privately;
+- require broader-machine validation first;
+- prepare announcement only, no release yet.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported scope
+
+Security reports should relate to the current SerapeumAI repository, packaged release candidate, or local runtime integration path.
+
+## Reporting
+
+Please open a private communication channel with the repository owner before publishing sensitive details publicly. If a private channel is not available, open a GitHub issue with a minimal, non-sensitive description and ask for a private follow-up path.
+
+Include:
+
+- affected commit or artifact identity;
+- operating system;
+- source run or packaged run;
+- local runtime configuration at a high level;
+- reproduction steps;
+- expected and actual behavior.
+
+Do not include confidential project documents, secrets, tokens, private models, or client data in public issues.
+
+## Product boundary
+
+SerapeumAI is a local-first AECO review workspace. Users remain responsible for protecting project files and local model/runtime configuration according to their own organization and project requirements.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,36 @@
+# Support
+
+SerapeumAI is currently managed through the GitHub repository.
+
+## Before opening an issue
+
+Please include:
+
+- Windows version;
+- whether you ran from source or packaged executable;
+- SerapeumAI commit or release artifact identity;
+- local runtime state;
+- relevant terminal output or log tail;
+- exact steps to reproduce;
+- whether the issue affects source run, packaged run, or both.
+
+## Good issue evidence
+
+For release and runtime issues, include:
+
+```text
+git status --short
+git rev-parse HEAD
+```
+
+For packaged-app issues, include:
+
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+```
+
+and describe the visible UI behavior.
+
+## Product boundary
+
+SerapeumAI provides engineering review assistance with evidence and provenance. Project teams remain responsible for their own professional review, approval, and contractual decisions.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,29 @@
+# Third-Party Notices
+
+This file summarizes third-party runtime and development components relevant to SerapeumAI publication hygiene.
+
+It is not a full legal dependency audit. Before a broad public release or commercial redistribution, run a complete dependency-license review against the exact locked environment and packaged artifact.
+
+## Runtime and platform posture
+
+SerapeumAI is a Windows-first, local-first desktop application. The current release-candidate path expects local runtime components to be installed and operated by the user where applicable.
+
+## Important component families
+
+The application may interact with or depend on components in these families, depending on the local environment and packaging state:
+
+- Python and Python packages used by the application.
+- Tk / desktop UI runtime components.
+- SQLite and local persistence components.
+- PDF/document processing libraries.
+- OCR/PDF rendering tools where installed, such as Tesseract and Poppler.
+- Local LM Studio-compatible model runtime.
+- Local embedding/runtime support libraries.
+
+## Local model/runtime note
+
+Local language models are not distributed by this notice unless explicitly bundled in a release artifact. Users are responsible for ensuring that any local model they install or load is used under its own license and terms.
+
+## No compliance warranty
+
+Third-party notices do not change SerapeumAI's product boundary. SerapeumAI provides review assistance and does not provide guaranteed legal, contractual, regulatory, or compliance approval.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,49 @@
+# Troubleshooting
+
+This guide covers common local runtime and release-candidate observations.
+
+## Runtime is not ready
+
+If model-backed analysis or chat is unavailable:
+
+- confirm the local runtime is open;
+- confirm the expected local endpoint is reachable;
+- confirm the expected model is loaded;
+- use **Re-check Runtime** inside the app.
+
+The app should report runtime state honestly rather than presenting unavailable model paths as ready.
+
+## GPU, VRAM, or thermal warnings
+
+On constrained laptops, especially around 8 GB VRAM, you may see:
+
+- GPU temperature warnings;
+- VRAM-limited model routing downgrade;
+- embedding model loading on CPU;
+- analysis model downgraded to chat model.
+
+These are performance/runtime caveats. They do not automatically invalidate deterministic extraction or stored facts.
+
+## Page-level model output parse retries
+
+Some pages may produce model-output parse retries during AI-assisted analysis.
+
+Interpretation:
+
+- deterministic extraction can still succeed;
+- Facts and File Inspector evidence lanes may still be valid;
+- AI Output Only remains non-governing unless promoted through review/certification;
+- retry or inspect the affected page when analysis quality matters.
+
+## Missing OCR/PDF tools
+
+Some document-processing paths may require tools such as Tesseract OCR or Poppler/PDF utilities. If they are missing, PDF/OCR processing may be limited.
+
+## Shutdown observations
+
+The current packaged smoke proof showed clean shutdown with no Tk post-destroy noise in the supplied tail. If you see shutdown noise, record:
+
+- exact steps;
+- terminal/log tail;
+- whether background jobs were running;
+- whether a project was open.

--- a/docs/internal/PUBLISH_TRUTH_STATEMENT.md
+++ b/docs/internal/PUBLISH_TRUTH_STATEMENT.md
@@ -1,27 +1,36 @@
 # SerapeumAI Publish Truth Statement
 
 Task class: release task / documentation-control artifact  
-Status: release-honesty checkpoint, not a final publish pass  
-Authority: current `main` after PR #121
+Status: final release-candidate truth statement pending owner publish decision  
+Authority: current `main` after PR #123 and packaging proof through #125
 
 ---
 
 ## 1. Purpose
 
-This document states what the current repository has actually proven during the Workspace Honesty and Engineering Evidence rails.
+This document states what the current repository and packaged artifact have actually proven.
 
-It is intentionally conservative. It does not claim final publish readiness until the final Windows release test, mounted workflow smoke test, and packaging proof are complete.
+It is conservative by design. It records release-candidate truth without expanding the product story beyond tested behavior.
 
 ---
 
 ## 2. Current authority
 
 ```text
-main includes PR #121
-latest main SHA: e5bdf53913cd25ac464ce36feb98ff3ab66b0065
-latest completed issue: #120 — Upgrade 3J — P6 Relation Uniqueness/Fidelity Proof/Patch
+main includes PR #123
+latest main SHA: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+latest completed issue: #125 — Upgrade 3M — Final Packaging Proof Gate
 master backlog: #24
+final publish-decision issue: #126
+publication docs/hygiene issue: #127
 preserved future planning branch: docs/total-quality-upgrade-v3-3
+```
+
+Release-candidate artifact:
+
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+size: 110206723 bytes
 ```
 
 ---
@@ -32,21 +41,21 @@ SerapeumAI is a Windows-first, local-first AECO review workspace.
 
 It provides evidence-backed review assistance through:
 
-- deterministic extraction,
-- fact building,
-- human review/certification,
-- lineage/provenance,
-- mounted File Inspector views,
-- mounted Facts page,
+- deterministic extraction;
+- fact building;
+- human review/certification;
+- lineage/provenance;
+- mounted File Inspector views;
+- mounted Facts page;
 - mounted Expert Chat.
 
 SerapeumAI is not:
 
-- a guaranteed-compliance engine,
-- a legal approval engine,
-- a cloud-required product,
-- a generic chatbot,
-- a design-authoring tool,
+- a guaranteed-compliance engine;
+- a legal approval engine;
+- a cloud-required product;
+- a generic chatbot;
+- a design-authoring tool;
 - an autonomous agent that silently edits project files or models.
 
 ---
@@ -85,32 +94,83 @@ Proven:
 - P6 critical-path unknown handling does not convert missing/unusable float into false membership or zero-count facts;
 - P6 relation fidelity preserves distinct `TASKPRED` rows when predecessor/successor match but relation type or lag differs.
 
+### Documentation honesty rail
+
+Proven:
+
+- README release honesty checkpoint was updated;
+- stale Packet 8 / Packets 1-7 language was removed;
+- completed proof rails and explicit non-enabled behavior are documented;
+- the parked Total Quality Upgrade branch is documented as future planning only.
+
+### Final source and packaging gates
+
+Proven:
+
+```text
+Release-relevant source regression: 115 passed in 1.81s
+Manual source smoke: PASS with caveats
+Documentation honesty: PASS
+Packaging proof: PASS
+Packaged app smoke: PASS
+```
+
+Packaging proof:
+
+- existing packaging script completed with exit code `0`;
+- fresh packaged artifact was produced;
+- no source/test/docs/packaging files changed;
+- no obvious bundled `src/tests`, `__pycache__`, or pytest cache was found in the dist package;
+- packaged executable launched on Windows;
+- packaged workflow smoke passed;
+- shutdown showed no Tk post-destroy / bgerror / invalid command noise in supplied tail.
+
 ---
 
 ## 5. Explicit non-enabled behavior
 
 The current repository does not enable or claim:
 
-- final publish pass;
-- final packaging proof;
-- dependency upgrades;
-- packaging file changes;
-- CPM engine implementation;
+- autonomous chat UI tool execution;
+- LLM tool-call parser in the visible chat UI;
+- MCP integration;
+- autonomous agent loop;
+- audit persistence implementation;
+- project memory implementation;
+- runtime provider provisioning, model download, or runtime control;
+- snapshot governance implementation;
+- Revit bridge implementation;
 - Schedule Truth Workspace implementation;
+- CPM engine implementation;
 - PDF VLM routing;
 - typed Office/CAD persistence;
 - generic Excel workbook semantic persistence;
 - IFC fallback parser when `ifcopenshell` is missing;
-- autonomous chat tool execution;
-- MCP integration;
-- runtime provider provisioning, model download, or runtime control;
-- Revit bridge implementation;
-- audit persistence implementation;
-- project memory implementation.
+- guaranteed legal, contractual, regulatory, or compliance approval.
 
 ---
 
-## 6. Packaging boundary
+## 6. Caveats
+
+The current artifact passed source and packaging gates, but these caveats remain relevant:
+
+```text
+LLM JSON parse failed on 2 analysis pages during source smoke
+Page analysis health: 28 / 30 healthy during source smoke
+GPU overheating warning at 86C on constrained 8 GB VRAM laptop
+VRAM-limited downgrade from analysis to chat can occur
+Embedding can load on CPU due to VRAM reserved/insufficient
+```
+
+Interpretation:
+
+- These are release-note/troubleshooting caveats.
+- They are not packaging blockers for the current artifact.
+- They should inform broader-machine validation and post-publish runtime/platform work.
+
+---
+
+## 7. Packaging boundary
 
 Packaging files remain sensitive and must not be edited unless explicitly approved:
 
@@ -122,7 +182,7 @@ No dependency upgrades are approved by this statement.
 
 ---
 
-## 7. Total Quality Upgrade branch boundary
+## 8. Total Quality Upgrade branch boundary
 
 The Total Quality Upgrade planning dossier is preserved on:
 
@@ -134,57 +194,31 @@ It is future planning only.
 
 It is not:
 
-- merged release authority,
-- current implementation authority,
-- packaging authority,
+- merged release authority;
+- current implementation authority;
+- packaging authority;
 - a final publish claim.
 
 Before using that branch later, reconcile it against actual `main` repo truth.
 
 ---
 
-## 8. Current publish truth
-
-Current state after Workspace Honesty and Engineering Evidence through PR #121:
+## 9. Current publish truth
 
 ```text
-Source/test closure rail: materially strengthened
-Documentation honesty checkpoint: active through #122
-Final Windows release test: not yet complete
-Mounted workflow smoke test: not yet complete
-Packaging proof: not yet complete
-Final publish verdict: NOT YET PASSED
+Source/test closure rail: PASS
+Documentation honesty: PASS
+Manual source smoke: PASS with caveats
+Packaging proof: PASS
+Packaged app smoke: PASS
+Final publish candidate artifact: AVAILABLE
+GitHub Release/tag: NOT CREATED BY THIS STATEMENT
+Owner publish decision: PENDING IN #126
+Publication docs/hygiene gate: ACTIVE IN #127
 ```
 
 ---
 
-## 9. Remaining release gates
+## 10. Next action
 
-Before a final publish pass:
-
-1. Complete documentation/release honesty checkpoint.
-2. Run final local Windows source regression suite.
-3. Run mounted workflow smoke test:
-   - open project,
-   - dashboard refresh,
-   - documents/file inspector,
-   - facts review actions,
-   - expert chat answer with evidence,
-   - close/change project,
-   - Red-X shutdown.
-4. Run packaging proof last.
-5. Launch packaged app on Windows and repeat the critical smoke path.
-6. Issue final PASS/FAIL publish verdict.
-
----
-
-## 10. Next action after this document
-
-After this checkpoint is merged and cleaned:
-
-```text
-Select either:
-- Schedule Truth Workspace design issue, or
-- final release-readiness gate,
-depending on owner priority and remaining risk.
-```
+Complete #127 repository publication documentation and hygiene gate, then return to #126 for explicit owner publish decision.


### PR DESCRIPTION
Closes #127.

Summary:
- Refreshes README to current #125 packaging-pass / #126 publish-decision-pending state.
- Updates docs/internal/PUBLISH_TRUTH_STATEMENT.md to current release-candidate truth after #125.
- Adds root Apache-2.0 LICENSE and NOTICE.
- Adds third-party notices summary.
- Adds release notes, changelog, install guide, troubleshooting guide, privacy posture, support guide, contributing guide, security policy, code of conduct, issue template, and PR template.

Publication controls:
- Describes shipped/proven behavior only.
- Records known runtime/performance caveats.
- Records explicit non-enabled behavior.
- Preserves docs/total-quality-upgrade-v3-3 as future planning only.
- Does not create a GitHub Release or tag.
- Does not change source, tests, packaging scripts/spec, dependencies, build outputs, or dist artifacts.

Changed files are docs/repo-metadata only:
- README.md
- LICENSE
- NOTICE
- THIRD_PARTY_NOTICES.md
- RELEASE_NOTES.md
- CHANGELOG.md
- INSTALL.md
- TROUBLESHOOTING.md
- PRIVACY.md
- SUPPORT.md
- CONTRIBUTING.md
- SECURITY.md
- CODE_OF_CONDUCT.md
- .github/ISSUE_TEMPLATE/bug_report.md
- .github/PULL_REQUEST_TEMPLATE.md
- docs/internal/PUBLISH_TRUTH_STATEMENT.md

Risk:
- Packaging risk: none; packaging files untouched.
- Windows risk: none; docs-only.
- Rollback risk: low.
- License/publication risk: reduced by adding root license and notices.

Verification:
- GitHub compare shows docs/repo-metadata files only.
- No forbidden source/test/packaging/build/dist paths changed.