### PR TITLE
Improve repository landing page and download UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,109 @@
 # SerapeumAI
 
-SerapeumAI is a **Windows-first, local-first AECO review workspace** for evidence-backed project review.
+**Windows-first local AECO review workspace for engineers.**
 
-It helps engineers and reviewers:
+SerapeumAI helps engineering and construction reviewers inspect project documents, separate deterministic evidence from AI-generated support, certify facts, and ask project questions with visible evidence lanes.
 
-- ingest project files into a local project workspace;
-- inspect deterministic extraction and AI-generated support separately;
-- review facts on the Facts page with lineage and evidence;
-- ask project questions in Expert Chat with direct answers and optional evidence lanes.
-
-SerapeumAI is **review assistance** with evidence and provenance. It is **not** a guaranteed-compliance engine, legal approval engine, autonomous design-authoring tool, or generic chatbot.
+It is built for engineers who need a local review workspace, not a generic chatbot.
 
 ---
 
-## Current publication status
+## Download for Windows
 
-Current release candidate authority:
+### Current status
 
 ```text
-main includes PR #123
-commit: 51bc3280e1adf9e3cc53859cb2f99bc0b8847548
-latest completed gate: #125 — Final Packaging Proof Gate
-artifact: dist\SerapeumAI_Portable\SerapeumAI.exe
-artifact size: 110206723 bytes
+Release candidate built and smoke-passed.
+GitHub Release download asset: pending owner release decision / upload.
 ```
 
-Release evidence currently recorded:
+The Windows executable proven during packaging is:
 
-- final Windows source regression: **PASS**;
-- manual source smoke: **PASS with caveats**;
-- documentation honesty checkpoint: **PASS**;
-- final packaging proof: **PASS**;
-- packaged app smoke: **PASS**;
-- final owner publish decision: **pending** in issue #126.
+```text
+dist\SerapeumAI_Portable\SerapeumAI.exe
+size: 110206723 bytes
+```
 
-A GitHub Release/tag has not been created by this README.
+After the GitHub Release asset is uploaded, engineers should download the Windows portable package from:
+
+```text
+GitHub Releases -> Latest release
+```
+
+Expected release asset name:
+
+```text
+SerapeumAI_Windows_Portable_v0.1.0-rc1.zip
+```
+
+Expected run path after unzip:
+
+```text
+SerapeumAI_Portable\SerapeumAI.exe
+```
+
+> The repository does **not** currently claim a live direct download asset until the GitHub Release is created and the portable ZIP is uploaded.
 
 ---
 
-## Supported posture
+## What SerapeumAI does
 
-- Baseline platform: **Windows**.
-- Core posture: **local-first** and **project-local**.
-- Runtime expectation: local LM Studio-compatible runtime for the current mounted runtime path.
-- Current publish generative runtime: `qwen2.5-coder-7b-instruct`.
-- Embeddings remain separate from the generative model.
-- Calculations and deterministic checks must be performed by application code/tools, not by LLM arithmetic.
+SerapeumAI helps engineers:
+
+- ingest project files into a local project workspace;
+- review project documents from a mounted Documents page;
+- inspect evidence through File Inspector lanes;
+- review and certify facts with lineage;
+- ask Expert Chat questions with evidence-labeled answers;
+- keep AI-generated support separate from trusted facts.
+
+SerapeumAI is **review assistance with evidence and provenance**. It is **not** a guaranteed-compliance engine, legal approval engine, autonomous design-authoring tool, or generic chatbot.
 
 ---
 
-## Quick start
+## Current release candidate authority
 
-Development run path:
+```text
+Repository authority: main after PR #128
+Current remote main SHA: 8c4b87372a85d592ec45409eac24e3ef79499114
+Packaging proof issue: #125 — PASS
+Publication hygiene issue: #127 / PR #128 — PASS
+Final publish decision: #126 — pending
+Broader Windows validation: #129 — pending
+```
+
+Packaging-proof source authority:
+
+```text
+51bc3280e1adf9e3cc53859cb2f99bc0b8847548
+```
+
+PR #128 was documentation/repository metadata only. It did not change source, tests, packaging files, dependencies, build outputs, or `dist` artifacts.
+
+---
+
+## Fast start
+
+### For users after a GitHub Release is published
+
+1. Open the latest GitHub Release.
+2. Download the Windows portable ZIP.
+3. Unzip it.
+4. Run:
+
+```text
+SerapeumAI_Portable\SerapeumAI.exe
+```
+
+### For local development
+
+From the repository root:
 
 ```powershell
 python run.py
 ```
 
-Packaged release-candidate path after a successful local build:
-
-```powershell
-.\dist\SerapeumAI_Portable\SerapeumAI.exe
-```
-
-For setup and runtime notes, see:
+See:
 
 - `INSTALL.md`
 - `TROUBLESHOOTING.md`
@@ -71,38 +111,93 @@ For setup and runtime notes, see:
 
 ---
 
-## Mounted workflow
+## Runtime expectation
 
-- **Dashboard**: project counts, runtime state, pipeline diagnostics, and honesty-oriented health labels.
-- **Documents**: browse project documents and open the File Inspector.
-- **File Inspector**:
-  1. Consolidated Review
-  2. Full Metadata
-  3. Raw Deterministic Extraction
-  4. AI Output Only
-- **Facts**: review facts, inspect meaning/source/review state, and open lineage/evidence.
-- **Expert Chat**:
-  - shows a direct answer first;
-  - labels the basis of the answer;
-  - exposes optional evidence lanes;
-  - resets visible chat history when the active project closes or changes;
-  - drops late responses/errors from old project sessions.
+The current mounted runtime path expects a local LM Studio-compatible runtime for model-backed analysis and chat features.
 
----
+The application should report runtime state honestly:
 
-## Trust and provenance model
+```text
+READY — local runtime/model is reachable and loaded
+MODEL_NOT_LOADED / not ready — runtime or model is unavailable
+```
 
-- `VALIDATED` and `HUMAN_CERTIFIED` facts are trusted answer sources.
-- `CANDIDATE` facts are visible for review but do not silently govern answers.
-- `REJECTED` facts are excluded from trusted answer paths.
-- Deterministic extraction and parser/OCR output remain separate from AI-generated support.
-- AI Output Only is non-governing unless promoted through review/certification.
-- Vector/retrieval stores are derived support, not governing truth.
-- Project A must not answer from Project B.
+Current publish generative runtime:
+
+```text
+qwen2.5-coder-7b-instruct
+```
+
+Embeddings are separate from the generative model.
+
+Calculations and deterministic checks must be performed by application code/tools, not by LLM arithmetic.
 
 ---
 
-## Current proven behavior
+## Engineering workflow
+
+### 1. Dashboard
+
+Project counts, runtime state, pipeline diagnostics, and health/honesty indicators.
+
+### 2. Documents
+
+Browse ingested project documents and open the File Inspector.
+
+### 3. File Inspector
+
+File Inspector separates evidence into four lanes:
+
+```text
+Consolidated Review
+Full Metadata
+Raw Deterministic Extraction
+AI Output Only
+```
+
+AI Output Only is non-governing unless promoted through review/certification.
+
+### 4. Facts
+
+Review facts, inspect meaning/source/review state, and open lineage/evidence.
+
+Trusted answer sources are:
+
+```text
+VALIDATED
+HUMAN_CERTIFIED
+```
+
+Candidate facts are visible for review but do not silently govern answers. Rejected facts are excluded from trusted answer paths.
+
+### 5. Expert Chat
+
+Expert Chat gives a direct answer first, labels the basis of the answer, and exposes optional evidence lanes.
+
+The visible chat is bound to the active project. Project A must not answer from Project B.
+
+---
+
+## Trust and evidence model
+
+SerapeumAI separates:
+
+- deterministic extraction;
+- parser/OCR output;
+- reviewed facts;
+- linked support;
+- AI-generated synthesis.
+
+Rules:
+
+- trusted facts outrank retrieval/vector support;
+- vector/retrieval stores are derived support, not governing truth;
+- AI Output Only is non-governing unless reviewed/promoted;
+- support-only answers must not be presented as certified truth.
+
+---
+
+## Proven release-candidate behavior
 
 Completed proof rails include:
 
@@ -116,13 +211,30 @@ Completed proof rails include:
 - P6 critical-path unknown honesty;
 - P6 relation uniqueness/fidelity;
 - File Inspector four-lane separation;
-- final packaging proof and packaged-app smoke.
+- final packaging proof;
+- packaged-app smoke on the owner Windows machine;
+- publication documentation/license/repository hygiene.
+
+---
+
+## Known caveats
+
+The current artifact passed packaging and packaged smoke, but these caveats remain important:
+
+- broader Windows machine validation is still pending;
+- constrained 8 GB VRAM laptops may show runtime, VRAM, or GPU-temperature warnings;
+- model routing may downgrade analysis to chat when VRAM is limited;
+- embeddings may load on CPU when VRAM is reserved or insufficient;
+- page-level model-output parse retries can occur during AI-assisted analysis;
+- `THIRD_PARTY_NOTICES.md` is a summary and is not a full legal dependency audit.
+
+These caveats do not change the owner-machine packaging proof, but they are relevant before a wider public announcement.
 
 ---
 
 ## Explicit non-enabled behavior
 
-The current repository does **not** enable or claim:
+The current release candidate does **not** enable or claim:
 
 - autonomous chat tool execution;
 - LLM tool-call parser in the visible chat UI;
@@ -143,19 +255,7 @@ The current repository does **not** enable or claim:
 
 ---
 
-## Known caveats
-
-The current artifact passed packaging and packaged smoke, but these caveats remain important for release notes and troubleshooting:
-
-- constrained 8 GB VRAM laptops may show runtime, VRAM, or GPU-temperature warnings;
-- model routing may downgrade analysis to chat when VRAM is limited;
-- embeddings may load on CPU when VRAM is reserved or insufficient;
-- page-level LLM JSON parse retries/errors can occur during analysis;
-- these caveats do not change deterministic extraction, facts, evidence lanes, or packaged smoke proof.
-
----
-
-## Repository and contribution rules
+## Repository rules for contributors
 
 - `src/**` is the primary editable source surface.
 - `run.py` and `run_tests.py` are editable only when needed.
@@ -165,7 +265,7 @@ The current artifact passed packaging and packaged smoke, but these caveats rema
 - Preserve Windows portability and packaging behavior.
 - Prefer minimal, reviewable diffs.
 
-See `CONTRIBUTING.md` for details.
+See `CONTRIBUTING.md`.
 
 ---
 


### PR DESCRIPTION
Closes #130.

Summary:
- Reworks README into an engineer-facing GitHub landing page.
- Adds a top-level Download for Windows section.
- Makes the packaged EXE path and size obvious.
- States clearly that the GitHub Release asset is pending and avoids a false live download claim.
- Documents expected future release asset name: `SerapeumAI_Windows_Portable_v0.1.0-rc1.zip`.
- Shows expected run path after unzip: `SerapeumAI_Portable\\SerapeumAI.exe`.
- Keeps runtime expectations, engineering workflow, evidence/trust model, known caveats, and non-enabled behavior visible.

Scope:
- README-only.
- No source changes.
- No test changes.
- No packaging file edits.
- No dependency changes.
- No build/dist artifacts.
- No GitHub Release/tag creation.

Risk:
- Packaging risk: none.
- Windows risk: none; docs-only.
- Rollback risk: low.
- Publication risk: reduced by making download status and pending release asset explicit.

Verification:
- GitHub compare shows only `README.md` changed.