### PR TITLE
Fix README runtime status encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The application should report runtime state honestly:
 
 ```text
 READY - local runtime/model is reachable and loaded
-MODEL_NOT_LOADED / not ready â€” runtime or model is unavailable
+MODEL_NOT_LOADED / not ready - runtime or model is unavailable
 ```
 
 Current publish generative runtime:


### PR DESCRIPTION
## Task class

documentation task

## Summary

Fix one README runtime status line with corrupted dash encoding.

## Touched files

- README.md

## Scope control

- [x] No source changes.
- [x] No test changes.
- [x] No packaging changes.
- [x] No dependency changes.
- [x] No build/dist/cache artifacts committed.

## Packaging / Windows risk

- Packaging risk: none
- Windows risk: none
- Rollback risk: low

## Verification

- git diff --check passed.
- Changed files limited to README.md.

## Notes

Two unrelated local cleanup files remained untracked and were not committed.