### PR TITLE
Phase 1A runtime provider discovery baseline

### DIFF
--- a/src/infra/adapters/llm_service.py
+++ b/src/infra/adapters/llm_service.py
@@ -34,6 +34,7 @@ import json
 import os
 import logging
 from contextlib import nullcontext
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -86,9 +87,18 @@ class LLMService:
 
         config = get_config()
 
-        # Check if LM Studio integration is enabled
-        lm_config = config.get_section("lm_studio") or {}
-        self.use_lm_studio = bool(lm_config.get("enabled", False))
+        # Check the selected provider
+        selected_provider = str(config.get("runtime.selected_provider") or "").strip().lower()
+        if not selected_provider:
+            # Fallback to legacy lm_studio.enabled flag if new setting isn't set
+            lm_config = config.get_section("lm_studio") or {}
+            if bool(lm_config.get("enabled", False)):
+                selected_provider = "lm_studio"
+            else:
+                selected_provider = "legacy_llama_cpp"
+
+        self.selected_provider = selected_provider
+        self.use_lm_studio = (selected_provider == "lm_studio")
 
         if self.use_lm_studio:
             # Use LM Studio v1 API + model router (auto benchmark selection)
@@ -105,11 +115,16 @@ class LLMService:
             logger.info("[LLMService] Using LM Studio publish runtime (single generative model, separate embeddings)")
             return
 
-        # Legacy mode: llama-cpp-python
+        if self.selected_provider == "local_review_only":
+            self.model = "local_review_only"
+            logger.info("[LLMService] Initialized in local-only review mode (AI features disabled)")
+            return
+
+        # Legacy mode / Embedded mode: llama-cpp-python
         if not _HAS_LLAMA_CPP:
             raise ImportError(
-                "llama-cpp-python not installed (required for legacy mode). "
-                "Install with: pip install llama-cpp-python"
+                "llama-cpp-python not installed (required for embedded mode). "
+                "Select LM Studio/local review mode or install the dependency outside SerapeumAI."
             )
 
         # Legacy: Unified Single Model Architecture
@@ -125,14 +140,55 @@ class LLMService:
         self._legacy_n_gpu_layers = int(n_gpu_layers if n_gpu_layers is not None else DEFAULT_GPU_LAYERS)
         self._legacy_verbose = bool(verbose)
 
-        logger.info("[LLMService] Initialized in legacy llama.cpp mode (single-model)")
+        logger.info("[LLMService] Initialized in embedded llama.cpp mode (single-model)")
+
+    def _resolve_gguf_path(self, model_name: str) -> str:
+        if not model_name:
+            return ""
+        candidate = Path(os.path.expandvars(os.path.expanduser(model_name)))
+        if candidate.exists():
+            return str(candidate.resolve())
+
+        from src.infra.config.configuration_manager import get_config
+        from src.infra.services.runtime_provider_discovery import configured_gguf_search_dirs
+
+        config = get_config()
+        name_lower = model_name.lower().strip()
+        for base_dir in configured_gguf_search_dirs(config):
+            if not base_dir.exists() or not base_dir.is_dir():
+                continue
+            direct_path = base_dir / model_name
+            if direct_path.exists() and direct_path.is_file():
+                return str(direct_path.resolve())
+            for path in base_dir.rglob("*.gguf"):
+                if path.name.lower() == name_lower:
+                    return str(path.resolve())
+                if path.stem.lower() == name_lower:
+                    return str(path.resolve())
+        return str(configured_gguf_search_dirs(config)[0] / model_name)
+
+    def _get_model_name_for_task(self, task_type: str) -> str:
+        from src.infra.config.configuration_manager import get_config
+        config = get_config()
+        if task_type in ("analysis", "reasoning", "entity_extraction", "summarization"):
+            model = config.get("runtime.selected_analysis_model") or config.get("models.analysis.model")
+        else:
+            model = config.get("runtime.selected_chat_model") or config.get("models.chat.model")
+        if not model or model == "auto":
+            model = self._legacy_model_path
+        return model
 
     def load_model(self, task_type: str = "universal"):
         """Explicitly trigger model loading."""
         if self.use_lm_studio:
             logger.info("[LLMService] LM Studio mode - models managed by server")
             return None
-        return self._get_model(task_type, model_path=self._legacy_model_path, auto_load=True)
+        if self.selected_provider == "local_review_only":
+            logger.info("[LLMService] Local review only mode - no model to load")
+            return None
+        model_name = self._get_model_name_for_task(task_type)
+        resolved_path = self._resolve_gguf_path(model_name)
+        return self._get_model(task_type, model_path=resolved_path, auto_load=True)
 
     # ------------------------------------------------------------------ #
     # Internal helpers
@@ -243,6 +299,9 @@ class LLMService:
         extra.pop("cancellation_token", None)
         extra.pop("timeout", None)
 
+        if self.selected_provider == "local_review_only":
+            raise RuntimeError("Inference refused: Active provider is local_review_only (AI features disabled).")
+
         # LM Studio mode
         if self.use_lm_studio:
             return self._chat_lm_studio(
@@ -276,10 +335,12 @@ class LLMService:
 
         user_prompt_log = ""
         try:
-            # Always get Universal Model (pass legacy path explicitly)
-            model_obj = self._get_model(task_type, model_path=self._legacy_model_path, auto_load=True)
+            # Resolve the model path based on the task type
+            model_name = self._get_model_name_for_task(task_type)
+            resolved_path = self._resolve_gguf_path(model_name)
+            model_obj = self._get_model(task_type, model_path=resolved_path, auto_load=True)
             if not model_obj:
-                raise RuntimeError("Universal Model failed to load.")
+                raise RuntimeError(f"Embedded model failed to load from path: {resolved_path}")
 
             inference_messages = messages  # keep multimodal list intact
 
@@ -634,9 +695,23 @@ class LLMService:
     # ------------------------------------------------------------------ #
 
     def verify_runtime_ready(self, task_type: str = "analysis", model: Optional[str] = None) -> Dict[str, Any]:
-        """Validate the LM Studio runtime contract before launching a larger workflow."""
+        """Validate the local runtime contract before launching a larger workflow."""
+        if self.selected_provider == "local_review_only":
+            raise RuntimeError("Verification failed: Local review only provider is selected (AI capabilities are disabled).")
+
         if not self.use_lm_studio or not self.lm_studio:
-            return {"ok": True, "mode": "legacy"}
+            # Embedded / legacy_llama_cpp mode
+            try:
+                from llama_cpp import Llama
+            except ImportError:
+                raise ImportError("llama-cpp-python package is not installed.")
+
+            model_name = model or self._get_model_name_for_task(task_type)
+            resolved_path = self._resolve_gguf_path(model_name)
+            if not os.path.exists(resolved_path):
+                raise FileNotFoundError(f"Model file not found: {resolved_path}")
+
+            return {"ok": True, "mode": "legacy", "model_path": resolved_path}
 
         chosen_model: Optional[str] = model
         if not chosen_model and self.router:

--- a/src/infra/adapters/lm_studio_provider_adapter.py
+++ b/src/infra/adapters/lm_studio_provider_adapter.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""LM Studio provider adapter for the ProviderRegistry."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from src.infra.adapters.lm_studio_service import LMStudioService
+from src.infra.services.provider_registry import ProviderAdapter, ProviderType
+
+
+class LMStudioProviderAdapter(ProviderAdapter):
+    """Adapter that wraps LMStudioService to conform to ProviderAdapter protocol."""
+
+    def __init__(self, lm_studio_service: LMStudioService):
+        self._lm_studio = lm_studio_service
+        self._provider_type = ProviderType.LM_STUDIO
+
+    def list_models(self) -> List[Dict[str, str]]:
+        """Return list of available models from LM Studio."""
+        models = self._lm_studio.list_models()
+        # Ensure each model has at least an 'id' and 'name' for consistency
+        result: List[Dict[str, str]] = []
+        for m in models:
+            model_id = m.get("id", "")
+            if not model_id:
+                continue
+            result.append({
+                "id": model_id,
+                "name": m.get("id", model_id),  # fallback to id as name
+            })
+        return result
+
+    def is_available(self) -> bool:
+        """Check if LM Studio is enabled and reachable."""
+        if not self._lm_studio.enabled:
+            return False
+        try:
+            # Use the existing reachability check
+            return self._lm_studio._is_server_reachable()
+        except Exception:
+            return False
+
+    def get_default_model(self) -> Optional[str]:
+        """Get the default model from LM Studio, if any."""
+        try:
+            return self._lm_studio.get_default_model()
+        except Exception:
+            return None
+
+    @property
+    def provider_type(self) -> ProviderType:
+        return self._provider_type

--- a/src/infra/services/model_role_manifest.py
+++ b/src/infra/services/model_role_manifest.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""
+Model Role Manifest - Defines the canonical model roles and their typical properties.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Dict, List, Optional
+
+
+class ModelRole(str, Enum):
+    """Canonical model roles in SerapeumAI."""
+    ROUTER = "router"
+    NARRATOR = "narrator"
+    STRUCTURED_JSON = "structured_json"
+    EVIDENCE_COMPRESSOR = "evidence_compressor"
+    VISION_HELPER = "vision_helper"
+    EMBEDDING = "embedding"
+    RERANKER = "reranker"
+
+
+class ModelSize(str, Enum):
+    """Relative model size categories."""
+    TINY = "tiny"
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"
+    XLARGE = "xlarge"
+
+
+class QuantizationQuality(str, Enum):
+    """Relative quantization quality (higher is better)."""
+    Q2 = "q2"
+    Q3 = "q3"
+    Q4 = "q4"
+    Q5 = "q5"
+    Q6 = "q6"
+    Q8 = "q8"
+    F16 = "f16"
+    F32 = "f32"
+
+
+@dataclass(frozen=True)
+class RoleCharacteristics:
+    """Characteristics that define what a model should be good at for a given role."""
+    role: ModelRole
+    description: str
+    preferred_size: ModelSize
+    preferred_quantization: List[QuantizationQuality]  # Ordered by preference
+    min_vram_mb: int  # Minimum VRAM required for comfortable operation
+    ram_sensitive: bool = False  # Whether performance is significantly impacted by RAM
+    description_template: str = ""  # Template for generating human-readable descriptions
+
+    def get_description(self, model_id: str = "") -> str:
+        """Get a human-readable description for this role."""
+        if self.description_template:
+            return self.description_template.format(model_id=model_id)
+        return self.description
+
+
+# Define the canonical role characteristics
+ROLE_CHARACTERISTICS: Dict[ModelRole, RoleCharacteristics] = {
+    ModelRole.ROUTER: RoleCharacteristics(
+        role=ModelRole.ROUTER,
+        description="Task routing and intent classification - lightweight and fast.",
+        preferred_size=ModelSize.TINY,
+        preferred_quantization=[QuantizationQuality.Q4, QuantizationQuality.Q5],
+        min_vram_mb=512,
+        ram_sensitive=False,
+        description_template="Router model ({model_id}) for fast task classification.",
+    ),
+    ModelRole.NARRATOR: RoleCharacteristics(
+        role=ModelRole.NARRATOR,
+        description="Main storyteller / conversational model - balanced for chat and reasoning.",
+        preferred_size=ModelSize.MEDIUM,
+        preferred_quantization=[QuantizationQuality.Q4, QuantizationQuality.Q5],
+        min_vram_mb=4096,  # 4GB for 7B Q4
+        ram_sensitive=True,
+        description_template="Narrator model ({model_id}) for general conversation and reasoning.",
+    ),
+    ModelRole.STRUCTURED_JSON: RoleCharacteristics(
+        role=ModelRole.STRUCTURED_JSON,
+        description="Structured output / tool calling - reliable JSON generation.",
+        preferred_size=ModelSize.MEDIUM,
+        preferred_quantization=[QuantizationQuality.Q5, QuantizationQuality.Q6],
+        min_vram_mb=4096,
+        ram_sensitive=False,
+        description_template="Structured JSON model ({model_id}) for tool calls and data extraction.",
+    ),
+    ModelRole.EVIDENCE_COMPRESSOR: RoleCharacteristics(
+        role=ModelRole.EVIDENCE_COMPRESSOR,
+        description="Evidence compression and summarization - concise and accurate.",
+        preferred_size=ModelSize.MEDIUM,
+        preferred_quantization=[QuantizationQuality.Q4, QuantizationQuality.Q5],
+        min_vram_mb=4096,
+        ram_sensitive=True,
+        description_template="Compressor model ({model_id}) for summarizing evidence.",
+    ),
+    ModelRole.VISION_HELPER: RoleCharacteristics(
+        role=ModelRole.VISION_HELPER,
+        description="Vision-language model for image understanding, OCR, and diagram parsing.",
+        preferred_size=ModelSize.MEDIUM,
+        preferred_quantization=[QuantizationQuality.Q4, QuantizationQuality.Q5],
+        min_vram_mb=6144,  # 6GB for 7B VL Q4 (vision models are larger)
+        ram_sensitive=True,
+        description_template="Vision helper model ({model_id}) for image and document understanding.",
+    ),
+    ModelRole.EMBEDDING: RoleCharacteristics(
+        role=ModelRole.EMBEDDING,
+        description="Text embedding model for retrieval and semantic search.",
+        preferred_size=ModelSize.SMALL,
+        preferred_quantization=[QuantizationQuality.F16],  # Embeddings often use float16
+        min_vram_mb=512,
+        ram_sensitive=False,
+        description_template="Embedding model ({model_id}) for semantic search and retrieval.",
+    ),
+    ModelRole.RERANKER: RoleCharacteristics(
+        role=ModelRole.RERANKER,
+        description="Re-ranking model to improve search result relevance.",
+        preferred_size=ModelSize.SMALL,
+        preferred_quantization=[QuantizationQuality.Q4, QuantizationQuality.Q5],
+        min_vram_mb=2048,
+        ram_sensitive=False,
+        description_template="Reranker model ({model_id}) for improving search relevance.",
+    ),
+}
+
+
+def get_role_characteristics(role: ModelRole) -> RoleCharacteristics:
+    """Get the characteristics for a given model role."""
+    return ROLE_CHARACTERISTICS.get(role, ROLE_CHARACTERISTICS[ModelRole.NARRATOR])
+
+
+def get_all_roles() -> List[ModelRole]:
+    """Get all defined model roles."""
+    return list(ModelRole)

--- a/src/infra/services/provider_adapters.py
+++ b/src/infra/services/provider_adapters.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Provider Adapters - Wrapper implementations for various LLM providers.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Dict, Any
+
+from src.infra.services.provider_registry import ProviderAdapter, ProviderType
+from src.infra.adapters.lm_studio_service import LMStudioService
+from src.infra.config.configuration_manager import get_config
+from src.infra.persistence.database_manager import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class LMStudioAdapter(ProviderAdapter):
+    """Adapter for LM Studio that implements the ProviderAdapter protocol."""
+
+    def __init__(self, db: Optional[DatabaseManager] = None):
+        config = get_config()
+        self._lm_studio = LMStudioService(config, db=db)
+
+    def list_models(self) -> List[Dict[str, str]]:
+        """
+        Return list of available models from LM Studio.
+        Each dict should have at least 'id' and optionally 'name'.
+        """
+        try:
+            # LMStudioService.list_models returns a list of dicts with 'id' and maybe other keys
+            models = self._lm_studio.list_models() or []
+            # Ensure each entry has an 'id' field; if not, use 'name' as fallback
+            result: List[Dict[str, str]] = []
+            for m in models:
+                if isinstance(m, dict):
+                    model_id = m.get("id") or m.get("name") or ""
+                    if model_id:
+                        # Normalize to have 'id' and 'name'
+                        result.append({
+                            "id": model_id,
+                            "name": m.get("name", model_id),
+                        })
+            return result
+        except Exception as e:
+            logger.warning(f"[LMStudioAdapter] Failed to list models: {e}")
+            return []
+
+    def is_available(self) -> bool:
+        """Check if LM Studio server is reachable."""
+        try:
+            return self._lm_studio._is_server_reachable()
+        except Exception:
+            return False
+
+    def get_default_model(self) -> Optional[str]:
+        """
+        Get the default model from LM Studio.
+        This could be the currently loaded model or the first available.
+        """
+        try:
+            status = self._lm_studio.get_status() or {}
+            model = status.get("model") or status.get("loaded_model")
+            if model:
+                return str(model)
+            # Fallback to first available model
+            models = self.list_models()
+            if models:
+                return models[0]["id"]
+        except Exception:
+            pass
+        return None
+
+
+# TODO: Add OllamaAdapter, LlamaCppAdapter, etc. as needed.
+
+def get_adapter_for_provider(provider_type: ProviderType, db: Optional[DatabaseManager] = None) -> Optional[ProviderAdapter]:
+    """
+    Factory function to get an adapter instance for a given provider type.
+    """
+    if provider_type == ProviderType.LM_STUDIO:
+        return LMStudioAdapter(db=db)
+    # Add other providers here
+    return None

--- a/src/infra/services/provider_registry.py
+++ b/src/infra/services/provider_registry.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+Provider Registry - Discovery and management of LLM providers.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Dict, List, Optional, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderType(str, Enum):
+    """Supported LLM provider types."""
+    LM_STUDIO = "lm_studio"
+    OLLAMA = "ollama"
+    LLAMA_CPP = "llama_cpp"  # Embedded llama.cpp
+    PROVIDER_MANAGED = "provider_managed"  # Generic provider-managed models
+    LOCAL_REVIEW_ONLY = "local_review_only"  # AI features disabled
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Protocol for provider adapters."""
+
+    def list_models(self) -> List[Dict[str, str]]:
+        """Return list of available models from the provider."""
+        ...
+
+    def is_available(self) -> bool:
+        """Check if the provider is available/runnable."""
+        ...
+
+    def get_default_model(self) -> Optional[str]:
+        """Get the default model for this provider, if any."""
+        ...
+
+
+class ProviderRegistry:
+    """
+    Registry for discovering and managing LLM providers.
+    """
+
+    def __init__(self):
+        self._providers: Dict[ProviderType, ProviderAdapter] = {}
+        self._selected_provider: Optional[ProviderType] = None
+
+    def register_provider(self, provider_type: ProviderType, adapter: ProviderAdapter) -> None:
+        """Register a provider adapter."""
+        self._providers[provider_type] = adapter
+        logger.info(f"[ProviderRegistry] Registered provider: {provider_type.value}")
+
+    def unregister_provider(self, provider_type: ProviderType) -> None:
+        """Unregister a provider."""
+        if provider_type in self._providers:
+            del self._providers[provider_type]
+            logger.info(f"[ProviderRegistry] Unregistered provider: {provider_type.value}")
+
+    def get_provider(self, provider_type: ProviderType) -> Optional[ProviderAdapter]:
+        """Get a registered provider adapter."""
+        return self._providers.get(provider_type)
+
+    def list_available_providers(self) -> List[ProviderType]:
+        """List providers that are currently available."""
+        available = []
+        for ptype, adapter in self._providers.items():
+            if adapter.is_available():
+                available.append(ptype)
+        return available
+
+    def set_selected_provider(self, provider_type: ProviderType) -> bool:
+        """Set the selected provider if it is available."""
+        adapter = self.get_provider(provider_type)
+        if adapter and adapter.is_available():
+            self._selected_provider = provider_type
+            logger.info(f"[ProviderRegistry] Selected provider: {provider_type.value}")
+            return True
+        logger.warning(f"[ProviderRegistry] Provider {provider_type.value} not available for selection.")
+        return False
+
+    def get_selected_provider(self) -> Optional[ProviderType]:
+        """Get the currently selected provider."""
+        return self._selected_provider
+
+    def get_selected_adapter(self) -> Optional[ProviderAdapter]:
+        """Get the adapter for the currently selected provider."""
+        if self._selected_provider is None:
+            return None
+        return self.get_provider(self._selected_provider)
+
+    def get_available_models(self) -> List[Dict[str, str]]:
+        """
+        Get all available models from the selected provider.
+        Returns list of dicts with at least {'id': str, 'name': str}.
+        """
+        adapter = self.get_selected_adapter()
+        if adapter is None:
+            return []
+        return adapter.list_models()
+
+    def get_default_model(self) -> Optional[str]:
+        """Get the default model from the selected provider."""
+        adapter = self.get_selected_adapter()
+        if adapter is None:
+            return None
+        return adapter.get_default_model()

--- a/src/infra/services/recommendation_engine.py
+++ b/src/infra/services/recommendation_engine.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""
+Recommendation Engine - Recommends models for specific roles based on hardware profile.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Dict, Any, Iterable, Tuple
+
+from src.infra.services.runtime_model_catalog import (
+    ModelCatalogEntry,
+    ModelRole,
+    ModelProfileClass,
+    ModelFormat,
+    ModelSizeClass,
+    HardwareSnapshot,
+    classify_hardware,
+    catalog_for_profile,
+    baseline_model_catalog,
+)
+from src.infra.services.provider_registry import ProviderType, ProviderRegistry
+from src.infra.services.provider_adapters import get_adapter_for_provider
+from src.infra.persistence.database_manager import DatabaseManager
+from src.infra.config.configuration_manager import get_config
+
+logger = logging.getLogger(__name__)
+
+
+class RecommendationEngine:
+    """
+    Recommends models for specific roles (router, narrator, etc.) based on hardware profile
+    and provider availability.
+    """
+
+    def __init__(
+        self,
+        db: Optional[DatabaseManager] = None,
+        provider_registry: Optional[ProviderRegistry] = None,
+        model_catalog: Optional[List[ModelCatalogEntry]] = None,
+    ):
+        self.db = db
+        self.provider_registry = provider_registry or ProviderRegistry()
+        self.model_catalog = model_catalog or baseline_model_catalog()
+        self._logger = logger
+
+        # Optionally register known providers
+        self._register_default_providers()
+
+    def _register_default_providers(self) -> None:
+        """Register known provider adapters (LM Studio, etc.) if they are available."""
+        try:
+            lm_studio_adapter = get_adapter_for_provider(
+                ProviderType.LM_STUDIO, db=self.db
+            )
+            if lm_studio_adapter and lm_studio_adapter.is_available():
+                self.provider_registry.register_provider(
+                    ProviderType.LM_STUDIO, lm_studio_adapter
+                )
+                self._logger.info(
+                    "[RecommendationEngine] Registered LM Studio provider adapter."
+                )
+        except Exception as e:
+            self._logger.debug(
+                f"[RecommendationEngine] Failed to register LM Studio adapter: {e}"
+            )
+
+        # TODO: Register Ollama, LlamaCpp, etc.
+
+    def recommend_for_role(
+        self,
+        role: ModelRole,
+        *,
+        hardware_snapshot: Optional[HardwareSnapshot] = None,
+        provider_type: Optional[ProviderType] = None,
+    ) -> Optional[ModelCatalogEntry]:
+        """
+        Recommend a model for the given role based on hardware and provider availability.
+
+        Args:
+            role: The model role to recommend for (e.g., ModelRole.NARRATOR).
+            hardware_snapshot: Optional hardware snapshot; if not provided, it will be detected.
+            provider_type: Optional provider type to prefer; if None, the engine will use the
+                           currently selected provider or auto-detect.
+
+        Returns:
+            A ModelCatalogEntry recommendation, or None if no suitable model is found.
+        """
+        # 1. Determine hardware profile
+        if hardware_snapshot is None:
+            hardware_snapshot = self._detect_hardware_snapshot()
+        profile = classify_hardware(hardware_snapshot)
+        self._logger.debug(
+            f"[RecommendationEngine] Hardware profile: {profile.value} "
+            f"(GPU: {hardware_snapshot.gpu_available}, VRAM: {hardware_snapshot.vram_total_mb}MB, "
+            f"RAM: {hardware_snapshot.ram_total_mb}MB)"
+        )
+
+        # 2. Filter catalog by profile class (allowed profiles)
+        allowed_entries = catalog_for_profile(profile, self.model_catalog)
+        self._logger.debug(
+            f"[RecommendationEngine] {len(allowed_entries)} entries match profile {profile.value}"
+        )
+
+        # 3. Further filter by role
+        role_entries = [e for e in allowed_entries if e.role == role]
+        self._logger.debug(
+            f"[RecommendationEngine] {len(role_entries)} entries for role {role.value}"
+        )
+
+        if not role_entries:
+            self._logger.warning(
+                f"[RecommendationEngine] No model catalog entries found for role {role.value} "
+                f"and profile {profile.value}"
+            )
+            return None
+
+        # 4. If a specific provider is requested, try to match provider-managed models
+        # For now, we only have local models in the catalog; provider-specific logic can be added later.
+        # We'll just return the first entry (could be improved with scoring).
+        # Sort by preference: prefer lower quantization (higher quality) for same size? 
+        # For now just pick first.
+        # We'll sort by quantization quality (roughly: higher number or letter is better) and size.
+        def _entry_score(entry: ModelCatalogEntry) -> tuple:
+            # Prefer higher quantization (e.g., Q6 > Q5 > Q4)
+            quant_map = {"Q2": 0, "Q3": 1, "Q4": 2, "Q5": 3, "Q6": 4, "Q8": 5}
+            quant_prefix = "".join([c for c in entry.quantization if c.isalpha() or c.isdigit()])
+            # Extract number if present
+            quant_num = 0
+            for part in quant_prefix.split('_'):
+                if part.isdigit():
+                    quant_num = int(part)
+                    break
+            # Prefer smaller size for constrained profiles? Actually, we already filtered by profile.
+            # For simplicity, we just use quantization and then size class (small < medium < large)
+            size_order = {ModelSizeClass.SMALL: 0, ModelSizeClass.MEDIUM: 1, ModelSizeClass.LARGE: 2}
+            return (
+                -quant_num,  # negative so higher quant is better (lower negative)
+                size_order[entry.estimated_size_class],
+                entry.model_id,  # tie-breaker
+            )
+
+        role_entries.sort(key=_entry_score)
+        recommended = role_entries[0]
+        self._logger.info(
+            f"[RecommendationEngine] Recommended model for {role.value}: {recommended.model_id} "
+            f"({recommended.display_name})"
+        )
+        return recommended
+
+    def recommend_for_all_roles(
+        self,
+        *,
+        hardware_snapshot: Optional[HardwareSnapshot] = None,
+        provider_type: Optional[ProviderType] = None,
+    ) -> Dict[ModelRole, Optional[ModelCatalogEntry]]:
+        """
+        Recommend a model for each role in the ModelRole enum.
+        """
+        result: Dict[ModelRole, Optional[ModelCatalogEntry]] = {}
+        for role in ModelRole:
+            result[role] = self.recommend_for_role(
+                role,
+                hardware_snapshot=hardware_snapshot,
+                provider_type=provider_type,
+            )
+        return result
+
+    def _detect_hardware_snapshot(self) -> HardwareSnapshot:
+        """
+        Detect hardware snapshot using the existing hardware utilities.
+        """
+        try:
+            from src.utils.hardware_utils import get_gpu_info
+
+            gpu_info = get_gpu_info() or {}
+            # Note: RAM detection is not in get_gpu_info; we'll need to get it separately.
+            # For now, we'll set RAM to 0 and let the caller provide it if needed.
+            # We can try to get RAM via psutil or platform, but to avoid extra deps, we'll leave it 0.
+            # The classify_hardware function uses ram_total_mb < 16000 for conservative, so if we don't have RAM,
+            # it might incorrectly classify as conservative. We'll try to get RAM from virtual memory.
+            ram_total_mb = 0
+            try:
+                import psutil
+
+                ram_total_mb = int(psutil.virtual_memory().total / (1024 * 1024))
+            except Exception:
+                pass  # Keep 0 if psutil not available
+
+            return HardwareSnapshot(
+                gpu_available=bool(gpu_info.get("available", False)),
+                vram_total_mb=int(gpu_info.get("vram_total_mb", 0)),
+                ram_total_mb=ram_total_mb,
+                gpu_name=str(gpu_info.get("gpu_name", "")),
+                os_name="",  # Not used in classification
+            )
+        except Exception as e:
+            self._logger.warning(f"[RecommendationEngine] Failed to detect hardware: {e}")
+            # Return a conservative default
+            return HardwareSnapshot(
+                gpu_available=False,
+                vram_total_mb=0,
+                ram_total_mb=0,
+                gpu_name="",
+                os_name="",
+            )
+
+
+# Convenience function for quick recommendation
+def recommend_model_for_role(
+    role: ModelRole,
+    *,
+    hardware_snapshot: Optional[HardwareSnapshot] = None,
+    provider_type: Optional[ProviderType] = None,
+    db: Optional[DatabaseManager] = None,
+) -> Optional[ModelCatalogEntry]:
+    engine = RecommendationEngine(db=db)
+    return engine.recommend_for_role(
+        role,
+        hardware_snapshot=hardware_snapshot,
+        provider_type=provider_type,
+    )

--- a/src/infra/services/recommendation_engine.py
+++ b/src/infra/services/recommendation_engine.py
@@ -118,7 +118,7 @@ class RecommendationEngine:
         # 4. If a specific provider is requested, try to match provider-managed models
         # For now, we only have local models in the catalog; provider-specific logic can be added later.
         # We'll just return the first entry (could be improved with scoring).
-        # Sort by preference: prefer lower quantization (higher quality) for same size? 
+        # Sort by preference: prefer lower quantization (higher quality) for same size?
         # For now just pick first.
         # We'll sort by quantization quality (roughly: higher number or letter is better) and size.
         def _entry_score(entry: ModelCatalogEntry) -> tuple:

--- a/src/infra/services/runtime_provider_discovery.py
+++ b/src/infra/services/runtime_provider_discovery.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """
 Read-only runtime provider discovery for SerapeumAI.
 
@@ -15,7 +15,9 @@ Wave 1B-1 / Upgrade 3S rules:
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Protocol
 from urllib import error, request
 from urllib.parse import urlparse
@@ -34,6 +36,71 @@ PROVIDER_MODE_LM_STUDIO_CLI_MANAGED = "LM_STUDIO_CLI_MANAGED"
 PROVIDER_MODE_OLLAMA_LOCAL = "OLLAMA_LOCAL"
 PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT = "LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT"
 PROVIDER_MODE_OPENAI_COMPATIBLE_LOCAL = "OPENAI_COMPATIBLE_LOCAL"
+
+
+def app_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def configured_gguf_search_dirs(config: Any = None) -> List[Path]:
+    values: List[Any] = []
+    if config is not None:
+        configured = None
+        get = getattr(config, "get", None)
+        if callable(get):
+            configured = get("runtime.gguf_model_dirs") or get("models.gguf_search_dirs")
+        if isinstance(configured, str):
+            values.extend(part.strip() for part in configured.split(os.pathsep))
+        elif isinstance(configured, (list, tuple)):
+            values.extend(configured)
+
+    values.extend(
+        [
+            app_root() / "models",
+            Path(os.path.expanduser("~")) / ".cache" / "lm-studio" / "models",
+        ]
+    )
+
+    out: List[Path] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value or "").strip()
+        if not text:
+            continue
+        path = Path(os.path.expandvars(os.path.expanduser(text)))
+        if not path.is_absolute():
+            path = app_root() / path
+        key = os.path.normcase(os.path.normpath(str(path)))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(path)
+    return out
+
+
+def scan_gguf_models(search_dirs: Iterable[Path]) -> List[Dict[str, Any]]:
+    listed_models: List[Dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for directory in search_dirs:
+        if not directory.exists() or not directory.is_dir():
+            continue
+        for path in directory.rglob("*.gguf"):
+            try:
+                abs_path = os.path.normpath(str(path.resolve()))
+                if abs_path in seen_paths:
+                    continue
+                seen_paths.add(abs_path)
+                listed_models.append(
+                    {
+                        "model_id": path.name,
+                        "display_name": path.stem,
+                        "path": abs_path,
+                        "size_bytes": path.stat().st_size,
+                    }
+                )
+            except Exception:
+                continue
+    return listed_models
 
 
 def _no_side_effects() -> Dict[str, bool]:
@@ -350,13 +417,70 @@ class OpenAICompatibleLocalDiscoveryAdapter(_OpenAICompatibleModelListingMixin, 
         )
 
 
+class LlamaCppDiscoveryAdapter(ProviderDiscoveryAdapter):
+    def __init__(self, *, config: Any = None) -> None:
+        self.config = config
+
+    @property
+    def name(self) -> str:
+        return "legacy_llama_cpp"
+
+    def discover(self) -> ProviderDiscoveryResult:
+        try:
+            from llama_cpp import Llama
+            has_llama = True
+        except ImportError:
+            has_llama = False
+
+        if not has_llama:
+            return ProviderDiscoveryResult(
+                provider_name="legacy_llama_cpp",
+                provider_type="embedded",
+                endpoint="in_process",
+                status=STATUS_NOT_DETECTED,
+                reason="llama-cpp-python package not installed",
+                capabilities=[],
+                side_effects=_no_side_effects(),
+                details={"modes_supported": [PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT]},
+                provider_mode=PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT,
+                provider_modes_supported=[PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT],
+                listed_models=[],
+            )
+
+        search_dirs = configured_gguf_search_dirs(self.config)
+        listed_models = scan_gguf_models(search_dirs)
+
+        status = STATUS_REACHABLE if listed_models else STATUS_DETECTED
+        reason = "" if listed_models else "llama-cpp-python is installed, but no .gguf models were found in configured local model directories."
+
+        return ProviderDiscoveryResult(
+            provider_name="legacy_llama_cpp",
+            provider_type="embedded",
+            endpoint="in_process",
+            status=status,
+            reason=reason,
+            capabilities=["local_runtime", "chat_completions", "embedded_inference"],
+            side_effects=_no_side_effects(),
+            details={
+                "modes_supported": [PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT],
+                "search_dirs": [str(path) for path in search_dirs],
+            },
+            provider_mode=PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT,
+            provider_modes_supported=[PROVIDER_MODE_LEGACY_LLAMA_CPP_AVAILABLE_IF_PRESENT],
+            listed_models=listed_models,
+        )
+
+
 class RuntimeProviderDiscoveryRegistry:
     def __init__(self, adapters: Optional[Iterable[ProviderDiscoveryAdapter]] = None) -> None:
         self.adapters = list(adapters or [])
 
     @classmethod
     def from_config(cls, config: Any) -> "RuntimeProviderDiscoveryRegistry":
-        providers: List[ProviderDiscoveryAdapter] = [LocalReviewOnlyDiscoveryAdapter()]
+        providers: List[ProviderDiscoveryAdapter] = [
+            LocalReviewOnlyDiscoveryAdapter(),
+            LlamaCppDiscoveryAdapter(config=config),
+        ]
 
         lm_cfg = config.get_section("lm_studio") if config else {}
         providers.append(

--- a/src/infra/services/runtime_setup_service.py
+++ b/src/infra/services/runtime_setup_service.py
@@ -12,6 +12,7 @@ import requests
 
 from src.infra.adapters.lm_studio_service import LMStudioRuntimeContractError, LMStudioService
 from src.infra.adapters.vector_store import EMBEDDING_MODEL
+from src.infra.services.runtime_provider_discovery import configured_gguf_search_dirs, scan_gguf_models
 
 logger = logging.getLogger(__name__)
 
@@ -470,6 +471,158 @@ class LocalRuntimeSetupService:
     # ------------------------------------------------------------------
     def detect_state(self) -> Dict[str, Any]:
         required = self.get_required_models()
+
+        # Check active provider
+        selected_provider = str(self.config.get("runtime.selected_provider") or "").strip().lower()
+        if not selected_provider:
+            selected_provider = "lm_studio"
+
+        if selected_provider == "local_review_only":
+            state = {
+                "status": STATUS_READY,
+                "message": "Local review only mode (no AI) is ready.",
+                "required_models": required,
+                "inventory": {
+                    "provider": "local_review_only",
+                    "server_running": False,
+                    "downloaded_llms": [],
+                    "loaded_models": [],
+                    "selected_models": {"chat": "None", "analysis": "None"},
+                    "loaded_roles": {"chat": "None", "analysis": "None"},
+                }
+            }
+            state["guidance"] = "AI features are disabled. Deterministic review features are active."
+            return state
+
+        if selected_provider == "legacy_llama_cpp":
+            # Embedded llama.cpp mode
+            try:
+                from llama_cpp import Llama
+                has_llama = True
+            except ImportError:
+                has_llama = False
+
+            search_dirs = configured_gguf_search_dirs(self.config)
+            discovered_ggufs = scan_gguf_models(search_dirs)
+            downloaded_llms = [
+                {
+                    "model_key": row.get("model_id", ""),
+                    "display_name": row.get("display_name", ""),
+                    "path": row.get("path", ""),
+                    "size_bytes": row.get("size_bytes", 0),
+                }
+                for row in discovered_ggufs
+            ]
+
+            # Get selected models
+            selected_chat = self.config.get("runtime.selected_chat_model") or self.config.get("models.chat.model") or ""
+            selected_analysis = self.config.get("runtime.selected_analysis_model") or self.config.get("models.analysis.model") or ""
+
+            if not selected_chat or selected_chat == "auto":
+                selected_chat = PUBLISH_GENERATIVE_MODEL
+            if not selected_analysis or selected_analysis == "auto":
+                selected_analysis = PUBLISH_GENERATIVE_MODEL
+
+            # Check if selected models exist
+            def find_model(model_name: str) -> bool:
+                if not model_name:
+                    return False
+                name_lower = model_name.lower().strip()
+                for row in downloaded_llms:
+                    candidates = [
+                        row.get("model_key"),
+                        row.get("display_name"),
+                        row.get("path"),
+                    ]
+                    if name_lower in {str(value or "").strip().lower() for value in candidates}:
+                        return True
+                return False
+
+            chat_exists = find_model(selected_chat)
+            analysis_exists = find_model(selected_analysis)
+
+            # Check loaded roles in ModelManager
+            try:
+                from src.infra.adapters.model_manager import ModelManager
+                mgr = ModelManager()
+                active_models = mgr.get_status().get("active_models", [])
+            except Exception:
+                active_models = []
+
+            loaded_roles = {
+                "chat": "chat" in active_models,
+                "analysis": "analysis" in active_models,
+            }
+
+            inventory = {
+                "provider": "legacy_llama_cpp",
+                "server_running": False,
+                "runtime_mode": "in_process",
+                "search_dirs": [str(path) for path in search_dirs],
+                "downloaded_llms": downloaded_llms,
+                "loaded_models": active_models,
+                "selected_models": {"chat": selected_chat, "analysis": selected_analysis},
+                "loaded_roles": loaded_roles,
+            }
+
+            if not has_llama:
+                state = {
+                    "status": STATUS_UNSUPPORTED_RUNTIME,
+                    "message": "llama-cpp-python is not installed in the Python environment.",
+                    "required_models": required,
+                    "inventory": inventory,
+                }
+                state["guidance"] = "Install llama-cpp-python in your environment to use embedded model features."
+                return state
+
+            if not downloaded_llms:
+                state = {
+                    "status": STATUS_CHAT_MODEL_MISSING,
+                    "message": "No GGUF models were found in configured local model directories.",
+                    "required_models": required,
+                    "inventory": inventory,
+                }
+                state["guidance"] = "Configure a local GGUF model directory or place a GGUF model under the app-root models directory, then re-check runtime."
+                return state
+
+            if not chat_exists or not analysis_exists:
+                missing = []
+                if not chat_exists:
+                    missing.append(f"chat model ({selected_chat})")
+                if not analysis_exists:
+                    missing.append(f"analysis model ({selected_analysis})")
+                missing_str = " and ".join(missing)
+                state = {
+                    "status": STATUS_CHAT_MODEL_MISSING,
+                    "message": f"Selected {missing_str} not found in models/ or LM Studio cache.",
+                    "required_models": required,
+                    "inventory": inventory,
+                }
+                state["guidance"] = "Configure available GGUF models in settings."
+                return state
+
+            # Check if models are loaded in memory
+            if not loaded_roles.get("chat") or not loaded_roles.get("analysis"):
+                missing_roles = [role for role in ("chat", "analysis") if not loaded_roles.get(role)]
+                role_text = ", ".join(missing_roles)
+                state = {
+                    "status": STATUS_MODEL_NOT_LOADED,
+                    "message": f"Load the selected session model(s) for: {role_text}.",
+                    "required_models": required,
+                    "inventory": inventory,
+                }
+                state["guidance"] = "Click Load Model to load GGUF models into memory."
+                return state
+
+            state = {
+                "status": STATUS_READY,
+                "message": "Local embedded GGUF intelligence runtime is ready.",
+                "required_models": required,
+                "inventory": inventory,
+            }
+            state["guidance"] = "Embedded llama.cpp is ready. Models are loaded in-process."
+            return state
+
         app_path = self._find_lmstudio_app()
         cli_path = self._find_lms_cli()
         inventory = self._inventory(app_path, cli_path)

--- a/src/tests/test_runtime_provider_discovery.py
+++ b/src/tests/test_runtime_provider_discovery.py
@@ -259,7 +259,7 @@ def test_from_config_includes_local_review_lm_studio_ollama_and_configured_opena
     registry = RuntimeProviderDiscoveryRegistry.from_config(config)
     names = [adapter.name for adapter in registry.adapters]
 
-    assert names == ["local_review_only", "lm_studio", "ollama", "local_openai_server"]
+    assert names == ["local_review_only", "legacy_llama_cpp", "lm_studio", "ollama", "local_openai_server"]
 
 
 def test_service_returns_dicts_with_required_status_fields():


### PR DESCRIPTION
## Summary
- Add a candidate Phase 1A runtime provider discovery baseline for #136.
- Add provider adapter/registry scaffolding, model role manifest, and recommendation-engine groundwork.
- Harden runtime setup/provider discovery so embedded llama.cpp/GGUF paths are app-root/config-relative instead of machine-specific.
- Keep LM Studio optional and preserve existing default behavior unless an embedded provider is explicitly selected.
- Keep embedded llama.cpp discovery honest when runtime packages or local models are absent.

## Issue alignment
- Intended for #136 Runtime Setup Wizard / hardware benchmark / model recommendation groundwork.
- Not intended for #151 R3-B Runtime Wizard read-model presenter.
- Does not implement the Runtime Setup Wizard UI.
- Does not benchmark.
- Does not download, install, load, or unload models.
- Does not touch packaging files or dependency files.

## Files
- `src/infra/adapters/llm_service.py`
- `src/infra/adapters/lm_studio_provider_adapter.py`
- `src/infra/services/model_role_manifest.py`
- `src/infra/services/provider_adapters.py`
- `src/infra/services/provider_registry.py`
- `src/infra/services/recommendation_engine.py`
- `src/infra/services/runtime_provider_discovery.py`
- `src/infra/services/runtime_setup_service.py`
- `src/tests/test_runtime_provider_discovery.py`

## Verification
Source-level checks run:
- `git diff --check`
- hardcoded-machine-path scan for `D:\SerapeumAI`, `d:/SerapeumAI`, and fixed `SerapeumAI/models` paths
- added-diff scan for install/download/network call patterns

Blocked checks:
- `python -m compileall -q src/infra/adapters src/infra/services`
- `python -m pytest -q src/tests/test_runtime_provider_discovery.py src/tests/test_runtime_provider_selection.py src/tests/test_runtime_setup_service.py src/tests/test_runtime_consent.py`

Blocked reason:
- Local Windows Python is unavailable through the Microsoft Store app-alias issue.

## Notes
- Review as a draft/candidate Phase 1A packet.
- Do not merge until Python/pytest validation runs in a working local environment.
- Runtime/tool stash backup remains local as `stash@{0}: runtime-tool-work-before-split`.
