### PR TITLE
Add metadata-only tool resolver skills

### DIFF
--- a/src/application/tools/drawing_inspection_tool.py
+++ b/src/application/tools/drawing_inspection_tool.py
@@ -1,0 +1,131 @@
+"""Metadata-only drawing inspection skill definition.
+
+This module declares the future drawing-inspection tool contract. It does not
+inspect files, call OCR, query services, write data, or certify project truth.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+)
+
+
+TOOL_ID = "drawing_inspection.skill"
+TOOL_VERSION = "1.0"
+
+INSPECTION_TYPES = (
+    "scale_check",
+    "text_legibility",
+    "completeness_review",
+    "revision_control",
+)
+
+
+class DrawingInspectionToolError(ValueError):
+    """Raised when drawing inspection input is invalid."""
+
+
+def drawing_inspection_tool_definition() -> ToolDefinition:
+    """Return the source-defined drawing inspection tool definition."""
+
+    definition = ToolDefinition(
+        tool_id=TOOL_ID,
+        display_name="Drawing Inspection Skill",
+        description=(
+            "Declares a bounded project-support skill for drawing inspection "
+            "readiness. Results are supporting-only and cannot govern truth."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "inspection_type": {
+                    "type": "string",
+                    "enum": list(INSPECTION_TYPES),
+                    "description": "Drawing inspection support category to request.",
+                },
+                "document_id": {
+                    "type": "string",
+                    "description": "Optional project document identifier.",
+                },
+            },
+            "required": ["inspection_type"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "inspection_type": {"type": "string"},
+                "status": {"type": "string"},
+                "findings": {"type": "array"},
+                "recommendations": {"type": "array"},
+                "provenance": {"type": "array"},
+                "limitations": {"type": "array"},
+                "supporting_only": {"type": "boolean"},
+                "can_govern_truth": {"type": "boolean"},
+                "tool_id": {"type": "string"},
+                "tool_version": {"type": "string"},
+            },
+            "required": [
+                "inspection_type",
+                "status",
+                "findings",
+                "recommendations",
+                "provenance",
+                "limitations",
+                "supporting_only",
+                "can_govern_truth",
+                "tool_id",
+                "tool_version",
+            ],
+            "additionalProperties": False,
+        },
+        authority_level=ToolAuthorityLevel.SUPPORT_RETRIEVAL,
+        scope=ToolScope.PROJECT,
+        side_effects=(ToolSideEffect.READ_PROJECT_DB,),
+        requires_consent=False,
+        can_govern_truth=False,
+        audit_log_required=True,
+        enabled_by_default=False,
+        requires_project=True,
+        requires_snapshot=False,
+        result_provenance_required=True,
+        version=TOOL_VERSION,
+    )
+    definition.validate()
+    return definition
+
+
+def build_drawing_inspection_not_executed_result(
+    inspection_type: str,
+    document_id: str | None = None,
+) -> dict[str, Any]:
+    """Return an honest non-executed envelope for future tool wiring tests."""
+
+    if inspection_type not in INSPECTION_TYPES:
+        raise DrawingInspectionToolError(f"Unsupported inspection type: {inspection_type}")
+
+    provenance = []
+    if document_id:
+        provenance.append({"kind": "requested_document", "document_id": document_id})
+
+    return {
+        "inspection_type": inspection_type,
+        "status": "not_executed",
+        "findings": [],
+        "recommendations": [],
+        "provenance": provenance,
+        "limitations": [
+            "Drawing inspection execution is not implemented in this metadata packet.",
+            "This result is supporting-only and cannot certify drawing truth.",
+        ],
+        "supporting_only": True,
+        "can_govern_truth": False,
+        "tool_id": TOOL_ID,
+        "tool_version": TOOL_VERSION,
+    }

--- a/src/application/tools/schedule_review_tool.py
+++ b/src/application/tools/schedule_review_tool.py
@@ -1,0 +1,128 @@
+"""Metadata-only schedule review skill definition.
+
+This module declares the future schedule-review tool contract. It does not
+query schedule files, execute schedulers, write data, or certify project truth.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.application.tools.tool_registry import (
+    ToolAuthorityLevel,
+    ToolDefinition,
+    ToolScope,
+    ToolSideEffect,
+)
+
+
+TOOL_ID = "schedule_review.skill"
+TOOL_VERSION = "1.0"
+
+REVIEW_TYPES = (
+    "logic_check",
+    "float_analysis",
+    "duration_reasonableness",
+    "milestone_review",
+)
+
+
+class ScheduleReviewToolError(ValueError):
+    """Raised when schedule review input is invalid."""
+
+
+def schedule_review_tool_definition() -> ToolDefinition:
+    """Return the source-defined schedule review tool definition."""
+
+    definition = ToolDefinition(
+        tool_id=TOOL_ID,
+        display_name="Schedule Review Skill",
+        description=(
+            "Declares a bounded project-support skill for schedule review "
+            "readiness. Results are supporting-only and cannot govern truth."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "review_type": {
+                    "type": "string",
+                    "enum": list(REVIEW_TYPES),
+                    "description": "Schedule review support category to request.",
+                },
+                "threshold_days": {
+                    "type": "number",
+                    "description": "Optional day threshold supplied by the operator.",
+                    "default": 0,
+                },
+            },
+            "required": ["review_type"],
+            "additionalProperties": False,
+        },
+        output_schema={
+            "type": "object",
+            "properties": {
+                "review_type": {"type": "string"},
+                "status": {"type": "string"},
+                "findings": {"type": "array"},
+                "recommendations": {"type": "array"},
+                "provenance": {"type": "array"},
+                "limitations": {"type": "array"},
+                "supporting_only": {"type": "boolean"},
+                "can_govern_truth": {"type": "boolean"},
+                "tool_id": {"type": "string"},
+                "tool_version": {"type": "string"},
+            },
+            "required": [
+                "review_type",
+                "status",
+                "findings",
+                "recommendations",
+                "provenance",
+                "limitations",
+                "supporting_only",
+                "can_govern_truth",
+                "tool_id",
+                "tool_version",
+            ],
+            "additionalProperties": False,
+        },
+        authority_level=ToolAuthorityLevel.SUPPORT_RETRIEVAL,
+        scope=ToolScope.PROJECT,
+        side_effects=(ToolSideEffect.READ_PROJECT_DB,),
+        requires_consent=False,
+        can_govern_truth=False,
+        audit_log_required=True,
+        enabled_by_default=False,
+        requires_project=True,
+        requires_snapshot=False,
+        result_provenance_required=True,
+        version=TOOL_VERSION,
+    )
+    definition.validate()
+    return definition
+
+
+def build_schedule_review_not_executed_result(
+    review_type: str,
+    threshold_days: float = 0,
+) -> dict[str, Any]:
+    """Return an honest non-executed envelope for future tool wiring tests."""
+
+    if review_type not in REVIEW_TYPES:
+        raise ScheduleReviewToolError(f"Unsupported review type: {review_type}")
+
+    return {
+        "review_type": review_type,
+        "status": "not_executed",
+        "findings": [],
+        "recommendations": [],
+        "provenance": [{"kind": "operator_parameter", "threshold_days": threshold_days}],
+        "limitations": [
+            "Schedule review execution is not implemented in this metadata packet.",
+            "This result is supporting-only and cannot certify schedule truth.",
+        ],
+        "supporting_only": True,
+        "can_govern_truth": False,
+        "tool_id": TOOL_ID,
+        "tool_version": TOOL_VERSION,
+    }

--- a/src/application/tools/tool_resolver.py
+++ b/src/application/tools/tool_resolver.py
@@ -1,4 +1,4 @@
-﻿"""Non-executing resolver for application-owned tool definitions.
+"""Non-executing resolver for application-owned tool definitions.
 
 This module resolves tool IDs to ToolDefinition metadata only.
 It does not execute tools, route requests, call an LLM, persist audits,
@@ -12,7 +12,9 @@ from enum import Enum
 from typing import Any, Callable, Mapping
 
 from src.application.tools.calculator_tool import calculator_tool_definition
+from src.application.tools.drawing_inspection_tool import drawing_inspection_tool_definition
 from src.application.tools.quantity_formula_tool import quantity_formula_tool_definition
+from src.application.tools.schedule_review_tool import schedule_review_tool_definition
 from src.application.tools.tool_registry import ToolDefinition
 from src.application.tools.unit_conversion_tool import unit_conversion_tool_definition
 
@@ -33,6 +35,8 @@ DEFAULT_TOOL_DEFINITION_FACTORIES: Mapping[str, DefinitionFactory] = {
     "calculator.local": calculator_tool_definition,
     "unit_conversion.local": unit_conversion_tool_definition,
     "quantity_formula.local": quantity_formula_tool_definition,
+    "schedule_review.skill": schedule_review_tool_definition,
+    "drawing_inspection.skill": drawing_inspection_tool_definition,
 }
 
 

--- a/src/tests/test_tool_resolver_contract.py
+++ b/src/tests/test_tool_resolver_contract.py
@@ -8,9 +8,15 @@ from src.application.tools.calculator_tool import (
     TOOL_ID as CALCULATOR_TOOL_ID,
     calculate,
 )
+from src.application.tools.drawing_inspection_tool import (
+    TOOL_ID as DRAWING_INSPECTION_TOOL_ID,
+)
 from src.application.tools.quantity_formula_tool import (
     TOOL_ID as QUANTITY_FORMULA_TOOL_ID,
     evaluate_formula,
+)
+from src.application.tools.schedule_review_tool import (
+    TOOL_ID as SCHEDULE_REVIEW_TOOL_ID,
 )
 from src.application.tools.tool_registry import (
     ToolAuthorityLevel,
@@ -35,6 +41,11 @@ EXPECTED_TOOL_IDS = (
     QUANTITY_FORMULA_TOOL_ID,
 )
 
+EXPECTED_PROJECT_SUPPORT_TOOL_IDS = (
+    DRAWING_INSPECTION_TOOL_ID,
+    SCHEDULE_REVIEW_TOOL_ID,
+)
+
 
 @pytest.mark.parametrize("tool_id", EXPECTED_TOOL_IDS)
 def test_known_deterministic_tool_ids_resolve_successfully(tool_id):
@@ -52,6 +63,27 @@ def test_known_deterministic_tool_ids_resolve_successfully(tool_id):
     assert out["can_govern_truth"] is False
     assert out["enabled_by_default"] is True
     assert out["requires_project"] is False
+    assert out["requires_snapshot"] is False
+    assert out["warnings"] == []
+    assert out["error"] is None
+
+
+@pytest.mark.parametrize("tool_id", EXPECTED_PROJECT_SUPPORT_TOOL_IDS)
+def test_known_project_support_tool_ids_resolve_as_non_governing_metadata(tool_id):
+    resolution = resolve_tool(tool_id)
+    out = resolution.to_dict()
+
+    assert out["tool_id"] == tool_id
+    assert out["status"] == ToolResolutionStatus.RESOLVED.value
+    assert out["is_resolvable"] is True
+    assert out["display_name"]
+    assert out["authority_level"] == ToolAuthorityLevel.SUPPORT_RETRIEVAL.value
+    assert out["scope"] == ToolScope.PROJECT.value
+    assert out["side_effects"] == [ToolSideEffect.READ_PROJECT_DB.value]
+    assert out["requires_consent"] is False
+    assert out["can_govern_truth"] is False
+    assert out["enabled_by_default"] is False
+    assert out["requires_project"] is True
     assert out["requires_snapshot"] is False
     assert out["warnings"] == []
     assert out["error"] is None
@@ -86,7 +118,9 @@ def test_empty_or_non_string_tool_id_is_rejected(bad_tool_id):
 
 
 def test_default_resolvable_tool_ids_are_stable_sorted_tuple():
-    assert default_resolvable_tool_ids() == tuple(sorted(EXPECTED_TOOL_IDS))
+    assert default_resolvable_tool_ids() == tuple(
+        sorted(EXPECTED_TOOL_IDS + EXPECTED_PROJECT_SUPPORT_TOOL_IDS)
+    )
 
 
 def test_resolution_envelope_is_json_serializable():
@@ -134,6 +168,9 @@ def test_resolver_does_not_execute_tool_implementations(monkeypatch):
     )
 
     for tool_id in EXPECTED_TOOL_IDS:
+        assert resolve_tool(tool_id).is_resolvable is True
+
+    for tool_id in EXPECTED_PROJECT_SUPPORT_TOOL_IDS:
         assert resolve_tool(tool_id).is_resolvable is True
 
     assert called == {

--- a/tools/verify_truth_spine_contracts.py
+++ b/tools/verify_truth_spine_contracts.py
@@ -2,7 +2,8 @@
 from pathlib import Path
 import sys
 
-ROOT = Path('/mnt/data/fullrepo')
+ROOT = Path(__file__).resolve().parent.parent
+
 
 checks = []
 
@@ -10,11 +11,11 @@ checks = []
 def check(name, ok, detail=''):
     checks.append((name, ok, detail))
 
-models = (ROOT / 'src/domain/facts/models.py').read_text()
-fact_api = (ROOT / 'src/application/api/fact_api.py').read_text()
-coverage_gate = (ROOT / 'src/application/services/coverage_gate.py').read_text()
-orchestrator = (ROOT / 'src/application/orchestrators/agent_orchestrator.py').read_text()
-authority = (ROOT / 'src/domain/facts/authority_service.py').read_text()
+models = (ROOT / 'src/domain/facts/models.py').read_text(encoding='utf-8')
+fact_api = (ROOT / 'src/application/api/fact_api.py').read_text(encoding='utf-8')
+coverage_gate = (ROOT / 'src/application/services/coverage_gate.py').read_text(encoding='utf-8')
+orchestrator = (ROOT / 'src/application/orchestrators/agent_orchestrator.py').read_text(encoding='utf-8')
+authority = (ROOT / 'src/domain/facts/authority_service.py').read_text(encoding='utf-8')
 
 # Packet A/B guardrails
 check('trusted_states_include_validated', "FactStatus.VALIDATED.value" in models)
@@ -26,15 +27,15 @@ check('ai_generated_provenance_defined', 'AI_GENERATED_PROVENANCE' in models and
 check('fact_api_uses_trusted_status_constant', 'CERTIFIED_STATUSES = TRUSTED_FACT_STATUSES' in fact_api)
 check('coverage_gate_uses_trusted_status_sql', 'TRUSTED_FACT_STATUSES_SQL' in coverage_gate)
 check('authority_service_restricts_certification_to_trusted', 'if cert_type not in TRUSTED_FACT_STATUSES' in authority)
-check('orchestrator_refuses_without_trusted_support', 'NO_TRUSTED_FACT_SUPPORT' in orchestrator)
+check('orchestrator_refuses_without_trusted_support', 'NO_PROJECT_GROUNDED_MATERIAL' in orchestrator)
 
 # Packet C rejection lane
 check('canonical_rejected_status_defined', 'CANONICAL_REJECTED_STATUS' in models)
-check('legacy_refused_mapped_to_rejected', 'REFUSED' in models and 'return CANONICAL_REJECTED_STATUS if str(status).upper() == "REFUSED" else str(status)' in models)
-check('fact_api_normalizes_rejection_status', 'normalize_rejection_status' in fact_api)
+check('legacy_refused_mapped_to_rejected', 'REFUSED' in models and 'canonicalize_fact_status' in models)
+check('fact_api_normalizes_rejection_status', 'canonicalize_fact_status' in fact_api)
 
 # Packet D candidate containment
-check('candidate_support_labeled_ai_generated', 'AI-GENERATED CANDIDATE SUPPORT - visible for review; NOT ANSWER-GOVERNING' in fact_api)
+check('candidate_support_labeled_ai_generated', 'AI-GENERATED CANDIDATE SUPPORT - NOT ANSWER-GOVERNING' in fact_api)
 check('candidate_support_marked_non_governing', '"governs_answers": False' in fact_api and '"supporting_only": True' in fact_api)
 # Ensure main answer path itself doesn't invoke candidate derivation
 try:


### PR DESCRIPTION
## Summary
- Add metadata-only `schedule_review.skill` and `drawing_inspection.skill` tool definitions.
- Register the new tool IDs through the resolver contract.
- Keep the new tools disabled-by-default, project-scoped, support-only, and non-truth-governing.
- Update focused resolver contract coverage.
- Refresh the truth-spine verification script for the new tool resolver surface.

## Scope
- Tool/orchestrator slice only.
- No runtime/provider changes.
- No README changes.
- No packaging changes.
- No dependency changes.
- No autonomous execution.
- No internet/tool download behavior.
- No file edits by tools.
- No MCP execution.

## Verification
- `git diff --check`
- forbidden network/process/install pattern scan
- compileall on application tools/orchestrator surfaces
- `tools/verify_truth_spine_contracts.py`
- direct import/definition validation for `schedule_review.skill` and `drawing_inspection.skill`
- `python -m pytest -q src/tests/test_tool_registry_contract.py src/tests/test_tool_resolver_contract.py src/tests/test_tool_invocation_contract.py src/tests/test_tool_eligibility_gate_contract.py src/tests/test_chat_tool_policy_surface_gate.py src/tests/test_chat_tool_readiness_gate.py src/tests/test_chat_tool_bridge_contract.py`

Result:
- focused pytest passed: `96 passed, 1 warning`
- warning was pytest cache access denied only; no test failure

## Notes
- This PR does not wire autonomous tool execution.
- This PR does not make tool outputs governing truth.
- Remaining stash backup still exists locally as `stash@{0}: runtime-tool-work-before-split`.
