### PR TITLE
Add Runtime Wizard read-model presenter

### DIFF
--- a/src/tests/test_runtime_wizard_presenter.py
+++ b/src/tests/test_runtime_wizard_presenter.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PRESENTER_PATH = ROOT / "src" / "ui" / "presenters" / "runtime_wizard_presenter.py"
+
+
+def _load_presenter():
+    spec = importlib.util.spec_from_file_location(
+        "runtime_wizard_presenter_under_test",
+        PRESENTER_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+presenter = _load_presenter()
+SECTION_ORDER = presenter.SECTION_ORDER
+present_runtime_wizard_sections = presenter.present_runtime_wizard_sections
+
+
+def _sections_by_id(out):
+    return {section["id"]: section for section in out["sections"]}
+
+
+def test_empty_input_produces_safe_not_ready_unknown_sections():
+    out = present_runtime_wizard_sections({})
+    sections = _sections_by_id(out)
+
+    assert out["executed"] is False
+    assert out["can_execute"] is False
+    assert sections["status"]["status"] == "unknown"
+    assert sections["provider"]["status"] == "not_ready"
+    assert sections["model_selection"]["status"] == "not_ready"
+    assert "unknown" in sections["status"]["summary"].lower()
+    assert "not ready" in sections["provider"]["summary"].lower()
+    assert "not treated as locally available" in sections["model_selection"]["summary"]
+
+
+def test_provider_model_and_recommendation_data_is_surfaced_deterministically():
+    out = present_runtime_wizard_sections(
+        {
+            "selected_provider": "lm_studio",
+            "selected_provider_mode": "lm_studio_manual_openai_compat",
+            "selected_chat_model": "qwen2.5-coder-7b-instruct",
+            "selected_analysis_model": "qwen2.5-coder-7b-instruct",
+            "model_selection_ready": True,
+            "model_readiness": "not_verified",
+            "available_models": [
+                {
+                    "model_id": "qwen2.5-coder-7b-instruct",
+                    "display_name": "Qwen Coder 7B",
+                }
+            ],
+            "runtime_status": {
+                "summary_status": "provider_reachable_model_not_verified",
+                "provider_count": 2,
+                "reachable_provider_count": 1,
+                "providers": [
+                    {
+                        "provider_name": "lm_studio",
+                        "display_status": "Reachable",
+                        "provider_mode_label": "LM Studio manual",
+                    }
+                ],
+            },
+            "model_recommendation": {
+                "profile_class": "balanced",
+                "model_posture": "balanced_7b_quantized",
+                "recommended_entries": [
+                    {
+                        "display_name": "Balanced 7B Local Q4",
+                        "model_id": "balanced-7b-local-q4",
+                        "role": "narrator",
+                        "quantization": "Q4_K_M",
+                    }
+                ],
+                "warnings": ["Advisory only."],
+                "constraints": ["No automatic runtime action."],
+            },
+        }
+    )
+    sections = _sections_by_id(out)
+
+    assert sections["status"]["status"] == "needs_model_verification"
+    assert sections["provider"]["rows"][0] == {
+        "label": "Selected provider",
+        "value": "lm_studio",
+    }
+    assert any(row["value"] == "Qwen Coder 7B" or row["value"] == "qwen2.5-coder-7b-instruct" for row in sections["model_selection"]["rows"])
+    assert any(row["label"] == "Balanced 7B Local Q4" for row in sections["recommendation"]["rows"])
+    assert any(row["value"] == "Advisory only." for row in sections["recommendation"]["rows"])
+
+
+def test_input_dictionary_is_not_mutated():
+    read_model = {
+        "selected_provider": "ollama",
+        "runtime_status": {"providers": [{"provider_name": "ollama"}]},
+        "model_recommendation": {"warnings": ["keep"]},
+    }
+    original = copy.deepcopy(read_model)
+
+    present_runtime_wizard_sections(read_model)
+
+    assert read_model == original
+
+
+def test_consent_and_side_effect_facts_are_displayed_but_not_executed():
+    out = present_runtime_wizard_sections(
+        {
+            "consent_requirements": ["provider_start"],
+            "side_effects": {
+                "provider_mutated": False,
+                "config_mutated": False,
+            },
+        }
+    )
+    section = _sections_by_id(out)["consent_side_effects"]
+
+    assert out["executed"] is False
+    assert out["can_execute"] is False
+    assert section["status"] == "display_only"
+    assert "never executes actions" in section["summary"]
+    assert {"label": "Consent requirement", "value": "provider_start"} in section["rows"]
+    assert {"label": "provider_mutated", "value": False} in section["rows"]
+
+
+def test_no_overclaim_when_provider_or_model_readiness_is_absent():
+    out = present_runtime_wizard_sections(
+        {
+            "runtime_status": {"summary_status": "no_provider_reachable"},
+            "selected_provider": "",
+            "selected_chat_model": "",
+            "selected_analysis_model": "",
+            "model_recommendation": {
+                "recommended_entries": [{"model_id": "balanced-7b-local-q4"}]
+            },
+        }
+    )
+    text = json.dumps(out).lower()
+
+    assert "no local provider is reachable" in text
+    assert "not treated as locally available" in text
+    assert "guidance only" in text
+    assert "loaded" not in text
+
+
+def test_output_is_json_serializable():
+    out = present_runtime_wizard_sections(
+        {
+            "runtime_status": {
+                "summary_status": "provider_discovery_unavailable",
+                "provider_count": 0,
+                "reachable_provider_count": 0,
+            }
+        }
+    )
+
+    assert json.loads(json.dumps(out, sort_keys=True)) == out
+
+
+def test_section_order_is_deterministic():
+    out = present_runtime_wizard_sections({})
+
+    assert out["section_order"] == list(SECTION_ORDER)
+    assert [section["id"] for section in out["sections"]] == list(SECTION_ORDER)

--- a/src/ui/presenters/runtime_wizard_presenter.py
+++ b/src/ui/presenters/runtime_wizard_presenter.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+"""
+Runtime Wizard read-model presenter.
+
+Transforms the existing runtime platform read-model dictionary into
+deterministic display sections for a future wizard surface.
+
+Presenter only:
+- no UI imports
+- no provider probing
+- no config mutation
+- no runtime actions
+- no benchmarks
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+SECTION_ORDER = (
+    "status",
+    "provider",
+    "model_selection",
+    "recommendation",
+    "consent_side_effects",
+    "next_steps",
+)
+
+
+def _safe_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _safe_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _text(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text if text else default
+
+
+def _number(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _bool_fact(value: Any) -> bool:
+    return bool(value) if isinstance(value, bool) else False
+
+
+def _section(section_id: str, title: str, status: str, summary: str, rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "id": section_id,
+        "title": title,
+        "status": status,
+        "summary": summary,
+        "rows": rows,
+    }
+
+
+def _status_section(runtime_status: Mapping[str, Any]) -> dict[str, Any]:
+    summary_status = _text(runtime_status.get("summary_status"), "unknown")
+    provider_count = _number(runtime_status.get("provider_count"))
+    reachable_count = _number(runtime_status.get("reachable_provider_count"))
+
+    if summary_status == "provider_reachable_model_not_verified":
+        status = "needs_model_verification"
+        summary = "A provider is reachable, but model/task readiness is not verified."
+    elif summary_status == "no_provider_reachable":
+        status = "not_ready"
+        summary = "No local provider is reachable."
+    elif summary_status == "provider_discovery_unavailable":
+        status = "unknown"
+        summary = "Runtime discovery did not return provider information."
+    else:
+        status = "unknown"
+        summary = "Runtime platform status is unknown."
+
+    return _section(
+        "status",
+        "Status",
+        status,
+        summary,
+        [
+            {"label": "Summary status", "value": summary_status},
+            {"label": "Reachable providers", "value": f"{reachable_count}/{provider_count}"},
+        ],
+    )
+
+
+def _provider_section(read_model: Mapping[str, Any], runtime_status: Mapping[str, Any]) -> dict[str, Any]:
+    selected_provider = _text(read_model.get("selected_provider"), "local_review_only")
+    selected_mode = _text(read_model.get("selected_provider_mode"), "unknown")
+    providers = [
+        row
+        for row in _safe_list(runtime_status.get("providers"))
+        if isinstance(row, Mapping)
+    ]
+
+    rows: list[dict[str, Any]] = [
+        {"label": "Selected provider", "value": selected_provider},
+        {"label": "Selected provider mode", "value": selected_mode},
+    ]
+    for provider in providers:
+        name = _text(provider.get("provider_name"), "unknown")
+        provider_status = _text(provider.get("display_status") or provider.get("status"), "unknown")
+        mode_label = _text(provider.get("provider_mode_label") or provider.get("provider_mode"), "unknown")
+        rows.append(
+            {
+                "label": name,
+                "value": provider_status,
+                "detail": mode_label,
+            }
+        )
+
+    status = "not_ready" if selected_provider == "local_review_only" else "display_only"
+    summary = (
+        "Provider information is display-only. No provider action is performed."
+    )
+    if not providers and selected_provider == "local_review_only":
+        summary = "No provider details were supplied. Runtime remains not ready for model-backed work."
+
+    return _section("provider", "Provider", status, summary, rows)
+
+
+def _model_selection_section(read_model: Mapping[str, Any]) -> dict[str, Any]:
+    selected_chat = _text(read_model.get("selected_chat_model"), "unknown")
+    selected_analysis = _text(read_model.get("selected_analysis_model"), "unknown")
+    readiness = _text(read_model.get("model_readiness"), "not_verified")
+    selection_ready = _bool_fact(read_model.get("model_selection_ready"))
+
+    models = [
+        row
+        for row in _safe_list(read_model.get("available_models"))
+        if isinstance(row, Mapping)
+    ]
+
+    rows: list[dict[str, Any]] = [
+        {"label": "Chat model", "value": selected_chat},
+        {"label": "Analysis model", "value": selected_analysis},
+        {"label": "Model readiness", "value": readiness},
+        {"label": "Selection complete", "value": selection_ready},
+    ]
+    for model in models:
+        model_id = _text(model.get("model_id") or model.get("id") or model.get("name"), "unknown")
+        display = _text(model.get("display_name"), model_id)
+        rows.append({"label": display, "value": model_id})
+
+    status = "selection_present" if selection_ready else "not_ready"
+    summary = "Selected model values are shown as configuration facts, not runtime actions."
+    if selected_chat == "unknown" or selected_analysis == "unknown":
+        summary = "Model selection is incomplete; unknown models are not treated as locally available."
+
+    return _section("model_selection", "Model Selection", status, summary, rows)
+
+
+def _recommendation_section(read_model: Mapping[str, Any]) -> dict[str, Any]:
+    recommendation = _safe_mapping(read_model.get("model_recommendation"))
+    profile = _text(recommendation.get("profile_class"), "unknown")
+    posture = _text(recommendation.get("model_posture"), "unknown")
+
+    rows: list[dict[str, Any]] = [
+        {"label": "Profile", "value": profile},
+        {"label": "Posture", "value": posture},
+    ]
+
+    for item in _safe_list(recommendation.get("recommended_entries")):
+        if not isinstance(item, Mapping):
+            continue
+        label = _text(item.get("display_name") or item.get("model_id"), "unknown")
+        model_id = _text(item.get("model_id"), "unknown")
+        role = _text(item.get("role"), "unspecified")
+        quantization = _text(item.get("quantization"), "")
+        detail = role if not quantization else f"{role} / {quantization}"
+        rows.append({"label": label, "value": model_id, "detail": detail})
+
+    for warning in _safe_list(recommendation.get("warnings")):
+        text = _text(warning)
+        if text:
+            rows.append({"label": "Warning", "value": text})
+
+    for constraint in _safe_list(recommendation.get("constraints")):
+        text = _text(constraint)
+        if text:
+            rows.append({"label": "Constraint", "value": text})
+
+    return _section(
+        "recommendation",
+        "Recommendation",
+        "guidance_only",
+        "Recommendation data is guidance only; it does not perform runtime actions.",
+        rows,
+    )
+
+
+def _consent_side_effects_section(read_model: Mapping[str, Any]) -> dict[str, Any]:
+    consent_requirements = [_text(item) for item in _safe_list(read_model.get("consent_requirements")) if _text(item)]
+    side_effects = _safe_mapping(read_model.get("side_effects"))
+
+    rows: list[dict[str, Any]] = []
+    for item in consent_requirements:
+        rows.append({"label": "Consent requirement", "value": item})
+    for key in sorted(str(name) for name in side_effects):
+        rows.append({"label": key, "value": _bool_fact(side_effects.get(key))})
+
+    if not rows:
+        rows.append({"label": "Consent and side effects", "value": "not supplied"})
+
+    return _section(
+        "consent_side_effects",
+        "Consent / Side Effects",
+        "display_only",
+        "Consent and side-effect values are displayed facts only; this presenter never executes actions.",
+        rows,
+    )
+
+
+def _next_steps_section(sections_by_id: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    status = _text(sections_by_id.get("status", {}).get("status"), "unknown")
+    model_status = _text(sections_by_id.get("model_selection", {}).get("status"), "unknown")
+
+    steps: list[str] = []
+    if status in {"unknown", "not_ready"}:
+        steps.append("Review local provider availability before model-backed work.")
+    if model_status == "not_ready":
+        steps.append("Select explicit chat and analysis model values before relying on model-backed features.")
+    if not steps:
+        steps.append("Review the displayed guidance and keep runtime actions user-triggered.")
+
+    rows = [{"label": f"Step {index}", "value": step} for index, step in enumerate(steps, start=1)]
+    return _section(
+        "next_steps",
+        "Next Steps",
+        "advisory",
+        "Next steps are advisory display text, not executable actions.",
+        rows,
+    )
+
+
+def present_runtime_wizard_sections(read_model: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return deterministic wizard display sections from an existing read model."""
+
+    model = _safe_mapping(read_model)
+    runtime_status = _safe_mapping(model.get("runtime_status"))
+
+    sections = [
+        _status_section(runtime_status),
+        _provider_section(model, runtime_status),
+        _model_selection_section(model),
+        _recommendation_section(model),
+        _consent_side_effects_section(model),
+    ]
+    sections_by_id = {section["id"]: section for section in sections}
+    sections.append(_next_steps_section(sections_by_id))
+
+    return {
+        "schema_version": 1,
+        "source": "runtime_wizard_presenter",
+        "executed": False,
+        "can_execute": False,
+        "section_order": list(SECTION_ORDER),
+        "sections": sections,
+    }


### PR DESCRIPTION
## Summary
- Add a pure Runtime Wizard read-model presenter for #151.
- Convert an existing runtime platform read-model mapping into deterministic wizard display sections.
- Add focused presenter tests for empty input, deterministic ordering, JSON serialization, no input mutation, consent/side-effect display, and no readiness overclaims.

## Scope
- Presenter/test only.
- No UI dialog wiring.
- No provider discovery changes.
- No runtime setup actions.
- No model loading/unloading.
- No benchmark execution.
- No downloads or installs.
- No packaging, dependency, README, or docs changes.

## Testing
- Passed: focused new presenter test (7 passed).
- Passed: compileall for the new presenter/test using the available bundled Python environment.
- Passed: forbidden pattern scan for network/process/install/model-action calls in the new files.
- Blocked: requested py -3.12 validation because this environment reported no installed Python for that launcher.
- Blocked: broader focused suite because existing tests import customtkinter, which is not available in this environment.